### PR TITLE
Updated Travis: Fix for Absolute Paths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,17 @@
 # build script for dedis/crypto libraries
-language: go
+env:
+    global:
+        - REPO="dedis/crypto"
+        - HOME="/home/travis"
+        - GOPATH="$HOME"
+        - PATH="$HOME/bin:$PATH"
+before_install:
+    - mkdir -p $HOME/src/github.com/dedis
+    - mkdir -p $HOME/bin
+    - ls $TRAVIS_BUILD_DIR
+    - mv $TRAVIS_BUILD_DIR $HOME/src/github.com/dedis
+    - cd $HOME/src/github.com/dedis/crypto
+    - go list -f '{{join .Deps "\n"}}' ./... | grep -v "^github.com/dedis/crypto" | xargs go get -t -v
 before_script:
     - git remote add production https://github.com/DeDiS/crypto.git
     - git fetch -a production


### PR DESCRIPTION
Updated travis to work for the absolute path necessity in go. Rather than
calling go get ./... as travis default does, the script manually only installs
third party dependencies leaving the dedis/crypto repository untouched.