### PR TITLE
Suite marshal

### DIFF
--- a/abstract/group.go
+++ b/abstract/group.go
@@ -13,44 +13,55 @@ This is an exponent in DSA-style groups,
 in which security is based on the Discrete Logarithm assumption,
 and a scalar multiplier in elliptic curve groups.
 */
-type Secret interface {
+type SecretInterface interface {
 	Marshaling
 
 	// Equality test for two Secrets derived from the same Group
-	Equal(s2 Secret) bool
+	Equal(s2 *Secret) bool
 
 	// Set equal to another Secret a
-	Set(a Secret) Secret
+	Set(a *Secret) *Secret
 
 	// Set to a small integer value
-	SetInt64(v int64) Secret
+	SetInt64(v int64) *Secret
 
 	// Set to the additive identity (0)
-	Zero() Secret
+	Zero() *Secret
 
 	// Set to the modular sum of secrets a and b
-	Add(a, b Secret) Secret
+	Add(a, b *Secret) *Secret
 
 	// Set to the modular difference a - b
-	Sub(a, b Secret) Secret
+	Sub(a, b *Secret) *Secret
 
 	// Set to the modular negation of secret a
-	Neg(a Secret) Secret
+	Neg(a *Secret) *Secret
 
 	// Set to the multiplicative identity (1)
-	One() Secret
+	One() *Secret
 
 	// Set to the modular product of secrets a and b
-	Mul(a, b Secret) Secret
+	Mul(a, b *Secret) *Secret
 
 	// Set to the modular division of secret a by secret b
-	Div(a, b Secret) Secret
+	Div(a, b *Secret) *Secret
 
 	// Set to the modular inverse of secret a
-	Inv(a Secret) Secret
+	Inv(a *Secret) *Secret
 
 	// Set to a fresh random or pseudo-random secret
-	Pick(rand cipher.Stream) Secret
+	Pick(rand cipher.Stream) *Secret
+}
+
+/*
+Secrets carry around their suite their using, so we can easily unmarshal
+into that structure, whereas unmarshalling into an interface needs the
+interface to be initialised first.
+*/
+
+type Secret struct {
+	Suite string
+	SecretInterface
 }
 
 /*
@@ -61,23 +72,23 @@ or an x,y point on an elliptic curve.
 A Point can contain a Diffie-Hellman public key,
 an ElGamal ciphertext, etc.
 */
-type Point interface {
+type PointInterface interface {
 	Marshaling
 
 	// Equality test for two Points derived from the same Group
-	Equal(s2 Point) bool
+	Equal(s2 *Point) bool
 
-	Null() Point // Set to neutral identity element
+	Null() *Point // Set to neutral identity element
 
 	// Set to this group's standard base point.
-	Base() Point
+	Base() *Point
 
 	// Pick and set to a point that is at least partly [pseudo-]random,
 	// and optionally so as to encode a limited amount of specified data.
 	// If data is nil, the point is completely [pseudo]-random.
 	// Returns this Point and a slice containing the remaining data
 	// following the data that was successfully embedded in this point.
-	Pick(data []byte, rand cipher.Stream) (Point, []byte)
+	Pick(data []byte, rand cipher.Stream) (*Point, []byte)
 
 	// Maximum number of bytes that can be reliably embedded
 	// in a single group element via Pick().
@@ -88,17 +99,26 @@ type Point interface {
 	Data() ([]byte, error)
 
 	// Add points so that their secrets add homomorphically
-	Add(a, b Point) Point
+	Add(a, b *Point) *Point
 
 	// Subtract points so that their secrets subtract homomorphically
-	Sub(a, b Point) Point
+	Sub(a, b *Point) *Point
 
 	// Set to the negation of point a
-	Neg(a Point) Point
+	Neg(a *Point) *Point
 
 	// Encrypt point p by multiplying with secret s.
 	// If p == nil, encrypt the standard base point Base().
-	Mul(p Point, s Secret) Point
+	Mul(p *Point, s *Secret) *Point
+}
+
+/*
+Point is a structure that holds also the suite used for easy unmarshalling.
+*/
+
+type Point struct {
+	Suite string
+	PointInterface
 }
 
 /*
@@ -138,11 +158,11 @@ XXX should probably delete the somewhat redundant ...Len() methods.
 type Group interface {
 	String() string
 
-	SecretLen() int // Max len of secrets in bytes
-	Secret() Secret // Create new secret
+	SecretLen() int  // Max len of secrets in bytes
+	Secret() *Secret // Create new secret
 
 	PointLen() int // Max len of point in bytes
-	Point() Point  // Create new point
+	Point() *Point // Create new point
 
 	PrimeOrder() bool // Returns true if group is prime-order
 }

--- a/abstract/list.go
+++ b/abstract/list.go
@@ -4,35 +4,35 @@ package abstract
 
 import (
 	"fmt"
-	//	"github.com/dedis/crypto/edwards"
-	//	"github.com/dedis/crypto/edwards/ed25519"
-	"github.com/dedis/crypto/nist"
 )
 
 // Suites represents a map from ciphersuite name to ciphersuite.
 type Suites map[string]Suite
 
+var allSuites Suites
+
 // Returns a map of all suites
-func All() Suites {
-	s := make(Suites)
-	s.add(nist.NewAES128SHA256P256())
-	//	s.add(nist.NewAES128SHA256QR512())
-	//	s.add(edwards.NewAES128SHA256Ed25519(false))
-	//	s.add(ed25519.NewAES128SHA256Ed25519(false))
-	return s
+func AllSuites() Suites {
+	if allSuites == nil {
+		allSuites = make(map[string]Suite, 0)
+	}
+	return allSuites
 }
 
 // StrintToSuite returns the suite for a string, or an error.
 func StringToSuite(s string) (Suite, error) {
-	suite, ok := All()[s]
+	suite, ok := allSuites[s]
 	if !ok {
 		return nil, fmt.Errorf("Didn't find suite %s", s)
 	}
 	return suite, nil
 }
 
-func (s Suites) add(suite Suite) {
-	s[suite.String()] = suite
+func AddSuite(suite Suite) {
+	_, exists := AllSuites()[suite.String()]
+	if !exists {
+		allSuites[suite.String()] = suite
+	}
 }
 
 // XXX add Stable() and Experimental() sub-lists?

--- a/abstract/list.go
+++ b/abstract/list.go
@@ -1,30 +1,29 @@
 // This package contains lists of ciphersuites
 // defined elsewhere in other packages.
-package suites
+package abstract
 
 import (
 	"fmt"
-	"github.com/dedis/crypto/abstract"
-	"github.com/dedis/crypto/edwards"
-	"github.com/dedis/crypto/edwards/ed25519"
+	//	"github.com/dedis/crypto/edwards"
+	//	"github.com/dedis/crypto/edwards/ed25519"
 	"github.com/dedis/crypto/nist"
 )
 
 // Suites represents a map from ciphersuite name to ciphersuite.
-type Suites map[string]abstract.Suite
+type Suites map[string]Suite
 
 // Returns a map of all suites
 func All() Suites {
 	s := make(Suites)
 	s.add(nist.NewAES128SHA256P256())
-	s.add(nist.NewAES128SHA256QR512())
-	s.add(edwards.NewAES128SHA256Ed25519(false))
-	s.add(ed25519.NewAES128SHA256Ed25519(false))
+	//	s.add(nist.NewAES128SHA256QR512())
+	//	s.add(edwards.NewAES128SHA256Ed25519(false))
+	//	s.add(ed25519.NewAES128SHA256Ed25519(false))
 	return s
 }
 
 // StrintToSuite returns the suite for a string, or an error.
-func StringToSuite(s string) (abstract.Suite, error) {
+func StringToSuite(s string) (Suite, error) {
 	suite, ok := All()[s]
 	if !ok {
 		return nil, fmt.Errorf("Didn't find suite %s", s)
@@ -32,7 +31,7 @@ func StringToSuite(s string) (abstract.Suite, error) {
 	return suite, nil
 }
 
-func (s Suites) add(suite abstract.Suite) {
+func (s Suites) add(suite Suite) {
 	s[suite.String()] = suite
 }
 

--- a/abstract/list_test.go
+++ b/abstract/list_test.go
@@ -1,25 +1,27 @@
-package abstract
+package abstract_test
 
 import (
+	"github.com/dedis/crypto/abstract"
+	_ "github.com/dedis/crypto/nist"
 	"github.com/dedis/crypto/test"
 	"testing"
 )
 
 func TestSuites(t *testing.T) {
-	s := All()
+	s := abstract.AllSuites()
 	for _, suite := range s {
 		test.TestSuite(suite)
 	}
 }
 
 func TestString(t *testing.T) {
-	_, err := StringToSuite("unknown")
+	_, err := abstract.StringToSuite("unknown")
 	if err == nil {
 		t.Fatal("Shouldn't find suite 'unknown'")
 	}
-	s := All()
-	for n := range s {
-		search, _ := StringToSuite(n)
+	s := abstract.AllSuites()
+	for n, _ := range s {
+		search, _ := abstract.StringToSuite(n)
 		if n != search.String() {
 			t.Fatal("Suite", n, "returned", search.String())
 		}

--- a/abstract/list_test.go
+++ b/abstract/list_test.go
@@ -1,4 +1,4 @@
-package suites
+package abstract
 
 import (
 	"github.com/dedis/crypto/test"

--- a/abstract/marshal.go
+++ b/abstract/marshal.go
@@ -1,0 +1,104 @@
+package abstract
+
+import (
+	"bytes"
+	"fmt"
+)
+
+/*
+Adjust marshaling size for the Secret-structure - needs to be adjusted
+with changes to how suites are stored
+*/
+func (s *Secret) MarshalSize() int {
+	return s.SecretInterface.MarshalSize() + 8
+}
+
+/*
+Marshal the suite, then the binary representation of the secret.
+*/
+func (s *Secret) MarshalBinary() (data []byte, err error) {
+	var b bytes.Buffer
+	bvalue, err := s.SecretInterface.MarshalBinary()
+	if err != nil {
+		return nil, err
+	}
+	fmt.Fprintln(&b, s.GetSuite().String(), len(bvalue))
+	b.Write(bvalue)
+	return b.Bytes(), nil
+}
+
+/*
+Unmarshal first the suite, create the secret, and unmarshal the
+binary representation of the secret.
+*/
+func (s *Secret) UnmarshalBinary(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
+	b := bytes.NewBuffer(data)
+	var length int
+	var suiteStr string
+	_, err := fmt.Fscanln(b, &suiteStr, &length)
+	bvalue := make([]byte, length)
+	b.Read(bvalue)
+	suite, err := StringToSuite(suiteStr)
+	if err != nil {
+		return err
+	}
+	secret := suite.Secret()
+	s.SecretInterface = secret.SecretInterface
+	s.SecretInterface.SetSuite(suite)
+	s.SecretInterface.UnmarshalBinary(bvalue)
+	return err
+}
+
+/*
+Adjust the marshal-size with regard to our storage of the suite
+*/
+func (p *Point) MarshalSize() int {
+	return p.PointInterface.MarshalSize() + 8
+}
+
+/*
+First write the suite, then the binary representation of the point.
+*/
+func (p *Point) MarshalBinary() (data []byte, err error) {
+	var b bytes.Buffer
+	bvalue, err := p.PointInterface.MarshalBinary()
+	if err != nil {
+		return nil, err
+	}
+	fmt.Fprintln(&b, p.GetSuite().String(), len(bvalue))
+	b.Write(bvalue)
+	return b.Bytes(), nil
+}
+
+/*
+Fetch the suite, create the point if it doesn't exist yet,
+then unmarshal the binary representation into it.
+*/
+func (p *Point) UnmarshalBinary(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
+	b := bytes.NewBuffer(data)
+	var length int
+	var suiteStr string
+	_, err := fmt.Fscanln(b, &suiteStr, &length)
+	bvalue := make([]byte, length)
+	b.Read(bvalue)
+	suite, err := StringToSuite(suiteStr)
+	if err != nil {
+		return err
+	}
+	point := suite.Point()
+	point.PointInterface.UnmarshalBinary(bvalue)
+	if p.PointInterface != nil {
+		p.Null()
+		p.Add(p, point)
+	} else {
+		p.PointInterface = point.PointInterface
+		p.SetSuite(suite)
+	}
+	return err
+}

--- a/abstract/marshal.go
+++ b/abstract/marshal.go
@@ -2,6 +2,7 @@ package abstract
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 )
 
@@ -53,6 +54,34 @@ func (s *Secret) UnmarshalBinary(data []byte) error {
 }
 
 /*
+Prepares for JSON-marshaling by putting all the data in a field
+called Data.
+*/
+func (s *Secret) MarshalJSON() (data []byte, err error) {
+	data, err = s.MarshalBinary()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(struct{ Data []byte }{Data: data})
+}
+
+/*
+Unmarshals the data from the point using the Data-field
+*/
+func (s *Secret) UnmarshalJSON(data []byte) error {
+	v_json := struct{ Data []byte }{}
+	err := json.Unmarshal(data, &v_json)
+	if err != nil {
+		return err
+	}
+	err = s.UnmarshalBinary(v_json.Data)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+/*
 Adjust the marshal-size with regard to our storage of the suite
 */
 func (p *Point) MarshalSize() int {
@@ -101,4 +130,32 @@ func (p *Point) UnmarshalBinary(data []byte) error {
 		p.SetSuite(suite)
 	}
 	return err
+}
+
+/*
+Prepares for JSON-marshaling by putting all the data in a field
+called Data.
+*/
+func (p *Point) MarshalJSON() (data []byte, err error) {
+	data, err = p.MarshalBinary()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(struct{ Data []byte }{Data: data})
+}
+
+/*
+Unmarshals the data from the point using the Data-field
+*/
+func (p *Point) UnmarshalJSON(data []byte) error {
+	v_json := struct{ Data []byte }{}
+	err := json.Unmarshal(data, &v_json)
+	if err != nil {
+		return err
+	}
+	err = p.UnmarshalBinary(v_json.Data)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/anon/anon.go
+++ b/anon/anon.go
@@ -11,10 +11,9 @@ type Set []*abstract.Point
 
 // A private key representing a member of an anonymity set
 type PriKey struct {
-	Set			// Public key-set
-	Mine int		// Index of the public key I own
-	Pri *abstract.Secret	// Private key for that public key
+	Set                   // Public key-set
+	Mine int              // Index of the public key I own
+	Pri  *abstract.Secret // Private key for that public key
 }
 
 // XXX name PubSet, PriSet?
-

--- a/anon/anon.go
+++ b/anon/anon.go
@@ -7,13 +7,13 @@ import (
 
 // An anon.Set represents an explicit anonymity set
 // as a list of public keys.
-type Set []abstract.Point
+type Set []*abstract.Point
 
 // A private key representing a member of an anonymity set
 type PriKey struct {
 	Set			// Public key-set
 	Mine int		// Index of the public key I own
-	Pri abstract.Secret	// Private key for that public key
+	Pri *abstract.Secret	// Private key for that public key
 }
 
 // XXX name PubSet, PriSet?

--- a/anon/enc.go
+++ b/anon/enc.go
@@ -9,7 +9,7 @@ import (
 
 // XXX belongs in crypto package?
 func keyPair(suite abstract.Suite, rand cipher.Stream,
-	hide bool) (abstract.Point, abstract.Secret, []byte) {
+	hide bool) (*abstract.Point, *abstract.Secret, []byte) {
 
 	x := suite.Secret().Pick(rand)
 	X := suite.Point().Mul(nil, x)
@@ -28,7 +28,7 @@ func keyPair(suite abstract.Suite, rand cipher.Stream,
 	}
 }
 
-func header(suite abstract.Suite, X abstract.Point, x abstract.Secret,
+func header(suite abstract.Suite, X *abstract.Point, x *abstract.Secret,
 	Xb, xb []byte, anonymitySet Set) []byte {
 
 	//fmt.Printf("Xb %s\nxb %s\n",
@@ -65,7 +65,7 @@ func encryptKey(suite abstract.Suite, rand cipher.Stream,
 // Decrypt and verify a key encrypted via encryptKey.
 // On success, returns the key and the length of the decrypted header.
 func decryptKey(suite abstract.Suite, ciphertext []byte, anonymitySet Set,
-	mine int, privateKey abstract.Secret,
+	mine int, privateKey *abstract.Secret,
 	hide bool) ([]byte, int, error) {
 
 	// Decode the (supposed) ephemeral public key from the front
@@ -180,7 +180,7 @@ func Encrypt(suite abstract.Suite, rand cipher.Stream, message []byte,
 // that will be accepted by the receiver without knowing the plaintext.
 //
 func Decrypt(suite abstract.Suite, ciphertext []byte, anonymitySet Set,
-	mine int, privateKey abstract.Secret, hide bool) ([]byte, error) {
+	mine int, privateKey *abstract.Secret, hide bool) ([]byte, error) {
 
 	// Decrypt and check the encrypted key-header.
 	xb, hdrlen, err := decryptKey(suite, ciphertext, anonymitySet,

--- a/anon/enc_test.go
+++ b/anon/enc_test.go
@@ -16,7 +16,7 @@ func ExampleEncrypt_1() {
 	rand := suite.Cipher([]byte("example"))
 
 	// Create a public/private keypair (X[mine],x)
-	X := make([]abstract.Point, 1)
+	X := make([]*abstract.Point, 1)
 	mine := 0                           // which public key is mine
 	x := suite.Secret().Pick(rand)      // create a private key x
 	X[mine] = suite.Point().Mul(nil, x) // corresponding public key X
@@ -56,7 +56,7 @@ func ExampleEncrypt_anonSet() {
 	rand := suite.Cipher([]byte("example"))
 
 	// Create an anonymity set of random "public keys"
-	X := make([]abstract.Point, 3)
+	X := make([]*abstract.Point, 3)
 	for i := range X { // pick random points
 		X[i], _ = suite.Point().Pick(nil, rand)
 	}

--- a/anon/sig.go
+++ b/anon/sig.go
@@ -9,17 +9,17 @@ import (
 
 // unlinkable ring signature
 type uSig struct {
-	C0 abstract.Secret
-	S  []abstract.Secret
+	C0 *abstract.Secret
+	S  []*abstract.Secret
 }
 
 // linkable ring signature
 type lSig struct {
 	uSig
-	Tag abstract.Point
+	Tag *abstract.Point
 }
 
-func signH1pre(suite abstract.Suite, linkScope []byte, linkTag abstract.Point,
+func signH1pre(suite abstract.Suite, linkScope []byte, linkTag *abstract.Point,
 	message []byte) abstract.Cipher {
 	H1pre := suite.Cipher(message) // m
 	if linkScope != nil {
@@ -30,7 +30,7 @@ func signH1pre(suite abstract.Suite, linkScope []byte, linkTag abstract.Point,
 	return H1pre
 }
 
-func signH1(suite abstract.Suite, H1pre abstract.Cipher, PG, PH abstract.Point) abstract.Secret {
+func signH1(suite abstract.Suite, H1pre abstract.Cipher, PG, PH *abstract.Point) *abstract.Secret {
 	H1 := H1pre.Clone()
 	PGb, _ := PG.MarshalBinary()
 	H1.Write(PGb)
@@ -106,7 +106,7 @@ func signH1(suite abstract.Suite, H1pre abstract.Cipher, PG, PH abstract.Point) 
 // they produced a signature of interest.
 //
 func Sign(suite abstract.Suite, random cipher.Stream, message []byte,
-	anonymitySet Set, linkScope []byte, mine int, privateKey abstract.Secret) []byte {
+	anonymitySet Set, linkScope []byte, mine int, privateKey *abstract.Secret) []byte {
 
 	// Note that Rivest's original ring construction directly supports
 	// heterogeneous rings containing public keys of different types -
@@ -119,7 +119,7 @@ func Sign(suite abstract.Suite, random cipher.Stream, message []byte,
 	// which are not readily feasible with the original ring construction.
 
 	n := len(anonymitySet)              // anonymity set size
-	L := []abstract.Point(anonymitySet) // public keys in anonymity set
+	L := []*abstract.Point(anonymitySet) // public keys in anonymity set
 	pi := mine
 
 	// If we want a linkable ring signature, produce correct linkage tag,
@@ -127,7 +127,7 @@ func Sign(suite abstract.Suite, random cipher.Stream, message []byte,
 	// Liu's scheme specifies the linkScope as a hash of the ring;
 	// this is one reasonable choice of linkage scope,
 	// but there are others, so we parameterize this choice.
-	var linkBase, linkTag abstract.Point
+	var linkBase, linkTag *abstract.Point
 	if linkScope != nil {
 		linkStream := suite.Cipher(linkScope)
 		linkBase, _ = suite.Point().Pick(nil, linkStream)
@@ -141,17 +141,17 @@ func Sign(suite abstract.Suite, random cipher.Stream, message []byte,
 
 	// Pick a random commit for my ring position
 	u := suite.Secret().Pick(random)
-	var UB, UL abstract.Point
+	var UB, UL *abstract.Point
 	UB = suite.Point().Mul(nil, u)
 	if linkScope != nil {
 		UL = suite.Point().Mul(linkBase, u)
 	}
 
 	// Build the challenge ring
-	s := make([]abstract.Secret, n)
-	c := make([]abstract.Secret, n)
+	s := make([]*abstract.Secret, n)
+	c := make([]*abstract.Secret, n)
 	c[(pi+1)%n] = signH1(suite, H1pre, UB, UL)
-	var P, PG, PH abstract.Point
+	var P, PG, PH *abstract.Point
 	P = suite.Point()
 	PG = suite.Point()
 	if linkScope != nil {
@@ -196,13 +196,13 @@ func Verify(suite abstract.Suite, message []byte, anonymitySet Set,
 	linkScope []byte, signatureBuffer []byte) ([]byte, error) {
 
 	n := len(anonymitySet)              // anonymity set size
-	L := []abstract.Point(anonymitySet) // public keys in ring
+	L := []*abstract.Point(anonymitySet) // public keys in ring
 
 	// Decode the signature
 	buf := bytes.NewBuffer(signatureBuffer)
-	var linkBase, linkTag abstract.Point
+	var linkBase, linkTag *abstract.Point
 	sig := lSig{}
-	sig.S = make([]abstract.Secret, n)
+	sig.S = make([]*abstract.Secret, n)
 	if linkScope != nil { // linkable ring signature
 		if err := suite.Read(buf, &sig); err != nil {
 			return nil, err
@@ -220,7 +220,7 @@ func Verify(suite abstract.Suite, message []byte, anonymitySet Set,
 	H1pre := signH1pre(suite, linkScope, linkTag, message)
 
 	// Verify the signature
-	var P, PG, PH abstract.Point
+	var P, PG, PH *abstract.Point
 	P = suite.Point()
 	PG = suite.Point()
 	if linkScope != nil {

--- a/anon/sig.go
+++ b/anon/sig.go
@@ -118,7 +118,7 @@ func Sign(suite abstract.Suite, random cipher.Stream, message []byte,
 	// e.g., we also easily obtain linkable ring signatures,
 	// which are not readily feasible with the original ring construction.
 
-	n := len(anonymitySet)              // anonymity set size
+	n := len(anonymitySet)               // anonymity set size
 	L := []*abstract.Point(anonymitySet) // public keys in anonymity set
 	pi := mine
 
@@ -195,7 +195,7 @@ func Sign(suite abstract.Suite, random cipher.Stream, message []byte,
 func Verify(suite abstract.Suite, message []byte, anonymitySet Set,
 	linkScope []byte, signatureBuffer []byte) ([]byte, error) {
 
-	n := len(anonymitySet)              // anonymity set size
+	n := len(anonymitySet)               // anonymity set size
 	L := []*abstract.Point(anonymitySet) // public keys in ring
 
 	// Decode the signature

--- a/anon/sig_test.go
+++ b/anon/sig_test.go
@@ -24,7 +24,7 @@ func ExampleSign_1() {
 	rand := suite.Cipher([]byte("example"))
 
 	// Create a public/private keypair (X[mine],x)
-	X := make([]abstract.Point, 1)
+	X := make([]*abstract.Point, 1)
 	mine := 0                           // which public key is mine
 	x := suite.Secret().Pick(rand)      // create a private key x
 	X[mine] = suite.Point().Mul(nil, x) // corresponding public key X
@@ -72,7 +72,7 @@ func ExampleSign_anonSet() {
 	rand := suite.Cipher([]byte("example"))
 
 	// Create an anonymity set of random "public keys"
-	X := make([]abstract.Point, 3)
+	X := make([]*abstract.Point, 3)
 	for i := range X { // pick random points
 		X[i], _ = suite.Point().Pick(nil, rand)
 	}
@@ -131,7 +131,7 @@ func ExampleSign_linkable() {
 	rand := suite.Cipher([]byte("example"))
 
 	// Create an anonymity set of random "public keys"
-	X := make([]abstract.Point, 3)
+	X := make([]*abstract.Point, 3)
 	for i := range X { // pick random points
 		X[i], _ = suite.Point().Pick(nil, rand)
 	}
@@ -258,12 +258,12 @@ var benchSig10Ed25519 = benchGenSigEd25519(10)
 var benchSig100Ed25519 = benchGenSigEd25519(100)
 
 func benchGenKeys(suite abstract.Suite,
-	nkeys int) ([]abstract.Point, abstract.Secret) {
+	nkeys int) ([]*abstract.Point, *abstract.Secret) {
 
 	rand := random.Stream
 
 	// Create an anonymity set of random "public keys"
-	X := make([]abstract.Point, nkeys)
+	X := make([]*abstract.Point, nkeys)
 	for i := range X { // pick random points
 		X[i], _ = suite.Point().Pick(nil, rand)
 	}
@@ -275,7 +275,7 @@ func benchGenKeys(suite abstract.Suite,
 	return X, x
 }
 
-func benchGenKeysOpenSSL(nkeys int) ([]abstract.Point, abstract.Secret) {
+func benchGenKeysOpenSSL(nkeys int) ([]*abstract.Point, *abstract.Secret) {
 	return benchGenKeys(nist.NewAES128SHA256P256(), nkeys)
 }
 func benchGenSigOpenSSL(nkeys int) []byte {
@@ -286,7 +286,7 @@ func benchGenSigOpenSSL(nkeys int) []byte {
 		0, benchPriOpenSSL)
 }
 
-func benchGenKeysEd25519(nkeys int) ([]abstract.Point, abstract.Secret) {
+func benchGenKeysEd25519(nkeys int) ([]*abstract.Point, *abstract.Secret) {
 	return benchGenKeys(edwards.NewAES128SHA256Ed25519(false), nkeys)
 }
 func benchGenSigEd25519(nkeys int) []byte {
@@ -297,7 +297,7 @@ func benchGenSigEd25519(nkeys int) []byte {
 		0, benchPriEd25519)
 }
 
-func benchSign(suite abstract.Suite, pub []abstract.Point, pri abstract.Secret,
+func benchSign(suite abstract.Suite, pub []*abstract.Point, pri *abstract.Secret,
 	niter int) {
 	rand := suite.Cipher([]byte("example"))
 	for i := 0; i < niter; i++ {
@@ -305,7 +305,7 @@ func benchSign(suite abstract.Suite, pub []abstract.Point, pri abstract.Secret,
 	}
 }
 
-func benchVerify(suite abstract.Suite, pub []abstract.Point,
+func benchVerify(suite abstract.Suite, pub []*abstract.Point,
 	sig []byte, niter int) {
 	for i := 0; i < niter; i++ {
 		tag, err := Verify(suite, benchMessage, Set(pub), nil, sig)

--- a/anon/skeme.go
+++ b/anon/skeme.go
@@ -22,11 +22,11 @@ import (
 type SKEME struct {
 	suite    abstract.Suite
 	hide     bool
-	lpri     PriKey          // local private key
-	rpub     Set             // remote public key
+	lpri     PriKey           // local private key
+	rpub     Set              // remote public key
 	lx       *abstract.Secret // local Diffie-Hellman private key
 	lX, rX   *abstract.Point  // local,remote Diffie-Hellman pubkeys
-	lXb, rXb []byte          // local,remote DH pubkeys byte-encoded
+	lXb, rXb []byte           // local,remote DH pubkeys byte-encoded
 
 	ms         abstract.Cipher // master symmetric shared stream
 	ls, rs     cipher.Stream   // local->remote,remote->local streams

--- a/anon/skeme.go
+++ b/anon/skeme.go
@@ -24,8 +24,8 @@ type SKEME struct {
 	hide     bool
 	lpri     PriKey          // local private key
 	rpub     Set             // remote public key
-	lx       abstract.Secret // local Diffie-Hellman private key
-	lX, rX   abstract.Point  // local,remote Diffie-Hellman pubkeys
+	lx       *abstract.Secret // local Diffie-Hellman private key
+	lX, rX   *abstract.Point  // local,remote Diffie-Hellman pubkeys
 	lXb, rXb []byte          // local,remote DH pubkeys byte-encoded
 
 	ms         abstract.Cipher // master symmetric shared stream

--- a/base64/base64.go
+++ b/base64/base64.go
@@ -27,7 +27,7 @@ import (
 type Encoding struct {
 	encode    string
 	decodeMap [256]byte
-	pad	  bool
+	pad       bool
 }
 
 const encodeStd = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
@@ -57,7 +57,6 @@ func NewEncoding(encoder string) *Encoding {
 func RawEncoding(encoder string) *Encoding {
 	return newEncoding(encoder, false)
 }
-
 
 // StdEncoding is the standard base64 encoding, as defined in
 // RFC 4648.
@@ -124,7 +123,7 @@ func (enc *Encoding) Encode(dst, src []byte) {
 		if len(src) >= 3 {
 			dst[2] = enc.encode[b2]
 			dst[3] = enc.encode[b3]
-		} else {		// Final incomplete quantum
+		} else { // Final incomplete quantum
 			if len(src) >= 2 {
 				dst[2] = enc.encode[b2]
 			}
@@ -233,7 +232,7 @@ func (enc *Encoding) EncodedLen(n int) int {
 	if enc.pad {
 		return (n + 2) / 3 * 4
 	} else {
-		return (n + 2) / 3 * 4 - 2 + (n + 2) % 3
+		return (n+2)/3*4 - 2 + (n+2)%3
 	}
 }
 
@@ -434,6 +433,6 @@ func (enc *Encoding) DecodedLen(n int) int {
 		return n / 4 * 3
 	} else {
 		// Unpadded base64 data may end with partial block of 2 or 3 characters.
-		return n / 4 * 3 + (n & 2)
+		return n/4*3 + (n & 2)
 	}
 }

--- a/base64/base64_test.go
+++ b/base64/base64_test.go
@@ -45,7 +45,6 @@ var pairs = []testpair{
 	{"sure.", "c3VyZS4="},
 }
 
-
 // Do nothing to a reference base64 string (leave in standard format)
 func stdRef(ref string) string {
 	return ref
@@ -69,8 +68,8 @@ func rawUrlRef(ref string) string {
 }
 
 type encodingTest struct {
-	enc *Encoding			// Encoding to test
-	conv func(string)string		// Reference string converter
+	enc  *Encoding           // Encoding to test
+	conv func(string) string // Reference string converter
 }
 
 var encodingTests = []encodingTest{
@@ -79,7 +78,6 @@ var encodingTests = []encodingTest{
 	encodingTest{RawStdEncoding, rawRef},
 	encodingTest{RawURLEncoding, rawUrlRef},
 }
-
 
 var bigtest = testpair{
 	"Twas brillig, and the slithy toves",
@@ -100,7 +98,7 @@ func TestEncode(t *testing.T) {
 			et := &encodingTests[i]
 			got := et.enc.EncodeToString([]byte(p.decoded))
 			testEqual(t, "Encode(%q) = %q, want %q", p.decoded,
-					got, et.conv(p.encoded))
+				got, et.conv(p.encoded))
 		}
 	}
 }
@@ -145,7 +143,7 @@ func TestDecode(t *testing.T) {
 			testEqual(t, "Decode(%q) = error %v, want %v", encoded, err, error(nil))
 			testEqual(t, "Decode(%q) = length %v, want %v", encoded, count, len(p.decoded))
 			if len(encoded) > 0 {
-				testEqual(t, "Decode(%q) = end %v, want %v", encoded, end, len(p.decoded) % 3 != 0)
+				testEqual(t, "Decode(%q) = end %v, want %v", encoded, end, len(p.decoded)%3 != 0)
 			}
 			testEqual(t, "Decode(%q) = %q, want %q", encoded, string(dbuf[0:count]), p.decoded)
 

--- a/config/file.go
+++ b/config/file.go
@@ -1,24 +1,22 @@
 package config
 
 import (
-	"os"
 	"errors"
 	"github.com/BurntSushi/toml"
 	"github.com/dedis/crypto/util"
+	"os"
 )
-
 
 // XXX it wouldn't be hard to parameterize the file format parser
 // rather than binding it to TOML.
 // Perhaps define an Encode/Decode interface
 // and create sub-packages for different compatible formats...
 
-
 // Cryptographic configuration file
 type File struct {
-	dirName string			// Configuration directory
-	data interface{}		// In-memory configuration state
-	keys map[string]KeyPair		// Key-pairs indexed by ciphersuite
+	dirName string             // Configuration directory
+	data    interface{}        // In-memory configuration state
+	keys    map[string]KeyPair // Key-pairs indexed by ciphersuite
 }
 
 func (f *File) init(appName string) error {
@@ -33,9 +31,9 @@ func (f *File) init(appName string) error {
 	}
 
 	// Sanity-check the config directory permission bits for security
-	if fi,err := os.Stat(confdir); err != nil || (fi.Mode() & 0077) != 0 {
-		return errors.New("Directory "+confdir+
-				" has insecure permissions")
+	if fi, err := os.Stat(confdir); err != nil || (fi.Mode()&0077) != 0 {
+		return errors.New("Directory " + confdir +
+			" has insecure permissions")
 	}
 
 	f.dirName = confdir
@@ -54,8 +52,8 @@ func (f *File) Load(appName string, configData interface{}) error {
 	}
 
 	// Read the config file if it exists
-	filename := f.dirName+"/config"
-	_,err := toml.DecodeFile(filename, configData)
+	filename := f.dirName + "/config"
+	_, err := toml.DecodeFile(filename, configData)
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
@@ -70,7 +68,7 @@ func (f *File) Load(appName string, configData interface{}) error {
 func (f *File) Save() error {
 
 	// Write the new config file
-	filename := f.dirName+"/config"
+	filename := f.dirName + "/config"
 	r := util.Replacer{}
 	if err := r.Open(filename); err != nil {
 		return err
@@ -86,8 +84,7 @@ func (f *File) Save() error {
 	// Commit the new config
 	if err := r.Commit(); err != nil {
 		return err
-	} 
+	}
 
 	return nil
 }
-

--- a/config/key.go
+++ b/config/key.go
@@ -14,7 +14,7 @@ import (
 // KeyPair represents a public/private keypair
 // together with the ciphersuite the key was generated from.
 type KeyPair struct {
-	Suite  abstract.Suite  // Ciphersuite this keypair is for
+	Suite  abstract.Suite   // Ciphersuite this keypair is for
 	Public *abstract.Point  // Public key
 	Secret *abstract.Secret // Secret key
 }

--- a/config/key.go
+++ b/config/key.go
@@ -15,8 +15,8 @@ import (
 // together with the ciphersuite the key was generated from.
 type KeyPair struct {
 	Suite  abstract.Suite  // Ciphersuite this keypair is for
-	Public abstract.Point  // Public key
-	Secret abstract.Secret // Secret key
+	Public *abstract.Point  // Public key
+	Secret *abstract.Secret // Secret key
 }
 
 // Generate a fresh public/private keypair with the given ciphersuite,

--- a/ds_test.go
+++ b/ds_test.go
@@ -52,8 +52,8 @@ func generateKeyPairList(n int) []*config.KeyPair {
 
 // Transforms a list of key pair into a list of only public keys
 // That list is distributed amongst the peers
-func generatePublicListFromPrivate(private []*config.KeyPair) []abstract.Point {
-	l := make([]abstract.Point, len(private))
+func generatePublicListFromPrivate(private []*config.KeyPair) []*abstract.Point {
+	l := make([]*abstract.Point, len(private))
 	for i := 0; i < len(private); i++ {
 		l[i] = private[i].Public
 	}

--- a/edwards/basic.go
+++ b/edwards/basic.go
@@ -71,13 +71,13 @@ func (P *basicPoint) HideDecode(rep []byte) {
 }
 
 // Equality test for two Points on the same curve
-func (P *basicPoint) Equal(P2 abstract.Point) bool {
+func (P *basicPoint) Equal(P2 *abstract.Point) bool {
 	E2 := P2.(*basicPoint)
 	return P.x.Equal(&E2.x) && P.y.Equal(&E2.y)
 }
 
 // Set point to be equal to P2.
-func (P *basicPoint) Set(P2 abstract.Point) abstract.Point {
+func (P *basicPoint) Set(P2 *abstract.Point) *abstract.Point {
 	E2 := P2.(*basicPoint)
 	P.c = E2.c
 	P.x.Set(&E2.x)
@@ -86,13 +86,13 @@ func (P *basicPoint) Set(P2 abstract.Point) abstract.Point {
 }
 
 // Set to the neutral element, which is (0,1) for twisted Edwards curves.
-func (P *basicPoint) Null() abstract.Point {
+func (P *basicPoint) Null() *abstract.Point {
 	P.Set(&P.c.null)
 	return P
 }
 
 // Set to the standard base point for this curve
-func (P *basicPoint) Base() abstract.Point {
+func (P *basicPoint) Base() *abstract.Point {
 	P.Set(&P.c.base)
 	return P
 }
@@ -101,7 +101,7 @@ func (P *basicPoint) PickLen() int {
 	return P.c.pickLen()
 }
 
-func (P *basicPoint) Pick(data []byte, rand cipher.Stream) (abstract.Point, []byte) {
+func (P *basicPoint) Pick(data []byte, rand cipher.Stream) (*abstract.Point, []byte) {
 	return P, P.c.pickPoint(P, data, rand)
 }
 
@@ -115,7 +115,7 @@ func (P *basicPoint) Data() ([]byte, error) {
 //	x' = ((x1*y2 + x2*y1) / (1 + d*x1*x2*y1*y2))
 //	y' = ((y1*y2 - a*x1*x2) / (1 - d*x1*x2*y1*y2))
 //
-func (P *basicPoint) Add(P1, P2 abstract.Point) abstract.Point {
+func (P *basicPoint) Add(P1, P2 *abstract.Point) *abstract.Point {
 	E1 := P1.(*basicPoint)
 	E2 := P2.(*basicPoint)
 	x1, y1 := E1.x, E1.y
@@ -142,19 +142,19 @@ func (P *basicPoint) Add(P1, P2 abstract.Point) abstract.Point {
 
 // Point doubling, which for Edwards curves can be accomplished
 // simply by adding a point to itself (no exceptions for equal input points).
-func (P *basicPoint) double() abstract.Point {
+func (P *basicPoint) double() *abstract.Point {
 	return P.Add(P, P)
 }
 
 // Subtract points so that their secrets subtract homomorphically
-func (P *basicPoint) Sub(A, B abstract.Point) abstract.Point {
+func (P *basicPoint) Sub(A, B *abstract.Point) *abstract.Point {
 	var nB basicPoint
 	return P.Add(A, nB.Neg(B))
 }
 
 // Find the negative of point A.
 // For Edwards curves, the negative of (x,y) is (-x,y).
-func (P *basicPoint) Neg(A abstract.Point) abstract.Point {
+func (P *basicPoint) Neg(A *abstract.Point) *abstract.Point {
 	E := A.(*basicPoint)
 	P.c = E.c
 	P.x.Neg(&E.x)
@@ -163,7 +163,7 @@ func (P *basicPoint) Neg(A abstract.Point) abstract.Point {
 }
 
 // Multiply point p by scalar s using the repeated doubling method.
-func (P *basicPoint) Mul(G abstract.Point, s abstract.Secret) abstract.Point {
+func (P *basicPoint) Mul(G *abstract.Point, s *abstract.Secret) *abstract.Point {
 	v := s.(*nist.Int).V
 	if G == nil {
 		return P.Base().Mul(P, s)
@@ -198,7 +198,7 @@ type BasicCurve struct {
 }
 
 // Create a new Point on this curve.
-func (c *BasicCurve) Point() abstract.Point {
+func (c *BasicCurve) Point() *abstract.Point {
 	P := new(basicPoint)
 	P.c = c
 	P.Set(&c.null)

--- a/edwards/curve.go
+++ b/edwards/curve.go
@@ -16,7 +16,7 @@ var one = big.NewInt(1)
 
 // Extension of Point interface for elliptic curve X,Y coordinate access
 type point interface {
-	abstract.Point
+	*abstract.Point
 
 	initXY(x, y *big.Int, curve abstract.Group)
 
@@ -43,7 +43,7 @@ type curve struct {
 	order  nist.Int // Order of appropriate subgroup as a ModInt
 	cofact nist.Int // Group's cofactor as a ModInt
 
-	null abstract.Point // Identity point for this group
+	null *abstract.Point // Identity point for this group
 
 	hide hiding // Uniform point encoding method
 }
@@ -58,7 +58,7 @@ func (c *curve) SecretLen() int {
 }
 
 // Create a new Secret for this curve.
-func (c *curve) Secret() abstract.Secret {
+func (c *curve) Secret() *abstract.Secret {
 	return nist.NewInt(0, &c.order.V)
 }
 
@@ -310,7 +310,7 @@ func (c *curve) pickPoint(P point, data []byte, rand cipher.Stream) []byte {
 
 	// Retry until we find a valid point
 	var x, y nist.Int
-	var Q abstract.Point
+	var Q *abstract.Point
 	for {
 		// Get random bits the size of a compressed Point encoding,
 		// in which the topmost bit is reserved for the x-coord sign.

--- a/edwards/ed25519/point.go
+++ b/edwards/ed25519/point.go
@@ -60,7 +60,7 @@ func (P *point) UnmarshalFrom(r io.Reader) (int, error) {
 }
 
 // Equality test for two Points on the same curve
-func (P *point) Equal(P2 abstract.Point) bool {
+func (P *point) Equal(P2 *abstract.Point) bool {
 
 	// XXX better to test equality without normalizing extended coords
 
@@ -76,19 +76,19 @@ func (P *point) Equal(P2 abstract.Point) bool {
 }
 
 // Set point to be equal to P2.
-func (P *point) Set(P2 abstract.Point) abstract.Point {
+func (P *point) Set(P2 *abstract.Point) *abstract.Point {
 	P.ge = P2.(*point).ge
 	return P
 }
 
 // Set to the neutral element, which is (0,1) for twisted Edwards curves.
-func (P *point) Null() abstract.Point {
+func (P *point) Null() *abstract.Point {
 	P.ge.Zero()
 	return P
 }
 
 // Set to the standard base point for this curve
-func (P *point) Base() abstract.Point {
+func (P *point) Base() *abstract.Point {
 	P.ge = baseext
 	return P
 }
@@ -100,7 +100,7 @@ func (P *point) PickLen() int {
 	return (255 - 8 - 8) / 8
 }
 
-func (P *point) Pick(data []byte, rand cipher.Stream) (abstract.Point, []byte) {
+func (P *point) Pick(data []byte, rand cipher.Stream) (*abstract.Point, []byte) {
 
 	// How many bytes to embed?
 	dl := P.PickLen()
@@ -163,7 +163,7 @@ func (P *point) Data() ([]byte, error) {
 	return b[1 : 1+dl], nil
 }
 
-func (P *point) Add(P1, P2 abstract.Point) abstract.Point {
+func (P *point) Add(P1, P2 *abstract.Point) *abstract.Point {
 	E1 := P1.(*point)
 	E2 := P2.(*point)
 
@@ -179,7 +179,7 @@ func (P *point) Add(P1, P2 abstract.Point) abstract.Point {
 	return P
 }
 
-func (P *point) Sub(P1, P2 abstract.Point) abstract.Point {
+func (P *point) Sub(P1, P2 *abstract.Point) *abstract.Point {
 	E1 := P1.(*point)
 	E2 := P2.(*point)
 
@@ -197,7 +197,7 @@ func (P *point) Sub(P1, P2 abstract.Point) abstract.Point {
 
 // Find the negative of point A.
 // For Edwards curves, the negative of (x,y) is (-x,y).
-func (P *point) Neg(A abstract.Point) abstract.Point {
+func (P *point) Neg(A *abstract.Point) *abstract.Point {
 	P.ge.Neg(&A.(*point).ge)
 	return P
 }
@@ -205,7 +205,7 @@ func (P *point) Neg(A abstract.Point) abstract.Point {
 // Multiply point p by scalar s using the repeated doubling method.
 // XXX This is vartime; for our general-purpose Mul operator
 // it would be far preferable for security to do this constant-time.
-func (P *point) Mul(A abstract.Point, s abstract.Secret) abstract.Point {
+func (P *point) Mul(A *abstract.Point, s *abstract.Secret) *abstract.Point {
 
 	// Convert the scalar to fixed-length little-endian form.
 	sb := s.(*nist.Int).V.Bytes()
@@ -250,7 +250,7 @@ func (c *Curve) SecretLen() int {
 }
 
 // Create a new Secret for the Ed25519 curve.
-func (c *Curve) Secret() abstract.Secret {
+func (c *Curve) Secret() *abstract.Secret {
 	//	if c.FullGroup {
 	//		return nist.NewInt(0, fullOrder)
 	//	} else {
@@ -264,7 +264,7 @@ func (c *Curve) PointLen() int {
 }
 
 // Create a new Point on the Ed25519 curve.
-func (c *Curve) Point() abstract.Point {
+func (c *Curve) Point() *abstract.Point {
 	P := new(point)
 	//P.c = c
 	return P

--- a/edwards/ext.go
+++ b/edwards/ext.go
@@ -80,7 +80,7 @@ func (P *extPoint) HideDecode(rep []byte) {
 //		iff
 //	(X1*Z2,Y1*Z2) == (X2*Z1,Y2*Z1)
 //
-func (P1 *extPoint) Equal(CP2 abstract.Point) bool {
+func (P1 *extPoint) Equal(CP2 *abstract.Point) bool {
 	P2 := CP2.(*extPoint)
 	var t1, t2 nist.Int
 	xeq := t1.Mul(&P1.X, &P2.Z).Equal(t2.Mul(&P2.X, &P1.Z))
@@ -88,7 +88,7 @@ func (P1 *extPoint) Equal(CP2 abstract.Point) bool {
 	return xeq && yeq
 }
 
-func (P *extPoint) Set(CP2 abstract.Point) abstract.Point {
+func (P *extPoint) Set(CP2 *abstract.Point) *abstract.Point {
 	P2 := CP2.(*extPoint)
 	P.c = P2.c
 	P.X.Set(&P2.X)
@@ -98,12 +98,12 @@ func (P *extPoint) Set(CP2 abstract.Point) abstract.Point {
 	return P
 }
 
-func (P *extPoint) Null() abstract.Point {
+func (P *extPoint) Null() *abstract.Point {
 	P.Set(&P.c.null)
 	return P
 }
 
-func (P *extPoint) Base() abstract.Point {
+func (P *extPoint) Base() *abstract.Point {
 	P.Set(&P.c.base)
 	return P
 }
@@ -129,7 +129,7 @@ func (P *extPoint) checkT() {
 	}
 }
 
-func (P *extPoint) Pick(data []byte, rand cipher.Stream) (abstract.Point, []byte) {
+func (P *extPoint) Pick(data []byte, rand cipher.Stream) (*abstract.Point, []byte) {
 	leftover := P.c.pickPoint(P, data, rand)
 	return P, leftover
 }
@@ -141,7 +141,7 @@ func (P *extPoint) Data() ([]byte, error) {
 }
 
 // Add two points using optimized extended coordinate addition formulas.
-func (P *extPoint) Add(CP1, CP2 abstract.Point) abstract.Point {
+func (P *extPoint) Add(CP1, CP2 *abstract.Point) *abstract.Point {
 	P1 := CP1.(*extPoint)
 	P2 := CP2.(*extPoint)
 	X1, Y1, Z1, T1 := &P1.X, &P1.Y, &P1.Z, &P1.T
@@ -165,7 +165,7 @@ func (P *extPoint) Add(CP1, CP2 abstract.Point) abstract.Point {
 }
 
 // Subtract points.
-func (P *extPoint) Sub(CP1, CP2 abstract.Point) abstract.Point {
+func (P *extPoint) Sub(CP1, CP2 *abstract.Point) *abstract.Point {
 	P1 := CP1.(*extPoint)
 	P2 := CP2.(*extPoint)
 	X1, Y1, Z1, T1 := &P1.X, &P1.Y, &P1.Z, &P1.T
@@ -190,7 +190,7 @@ func (P *extPoint) Sub(CP1, CP2 abstract.Point) abstract.Point {
 
 // Find the negative of point A.
 // For Edwards curves, the negative of (x,y) is (-x,y).
-func (P *extPoint) Neg(CA abstract.Point) abstract.Point {
+func (P *extPoint) Neg(CA *abstract.Point) *abstract.Point {
 	A := CA.(*extPoint)
 	P.c = A.c
 	P.X.Neg(&A.X)
@@ -227,7 +227,7 @@ func (P *extPoint) double() {
 // switching between projective and extended coordinates during
 // scalar multiplication.
 //
-func (P *extPoint) Mul(G abstract.Point, s abstract.Secret) abstract.Point {
+func (P *extPoint) Mul(G *abstract.Point, s *abstract.Secret) *abstract.Point {
 	v := s.(*nist.Int).V
 	if G == nil {
 		return P.Base().Mul(P, s)
@@ -276,7 +276,7 @@ type ExtendedCurve struct {
 }
 
 // Create a new Point on this curve.
-func (c *ExtendedCurve) Point() abstract.Point {
+func (c *ExtendedCurve) Point() *abstract.Point {
 	P := new(extPoint)
 	P.c = c
 	//P.Set(&c.null)

--- a/edwards/proj.go
+++ b/edwards/proj.go
@@ -72,7 +72,7 @@ func (P *projPoint) HideDecode(rep []byte) {
 //		iff
 //	(X1*Z2,Y1*Z2) == (X2*Z1,Y2*Z1)
 //
-func (P1 *projPoint) Equal(CP2 abstract.Point) bool {
+func (P1 *projPoint) Equal(CP2 *abstract.Point) bool {
 	P2 := CP2.(*projPoint)
 	var t1, t2 nist.Int
 	xeq := t1.Mul(&P1.X, &P2.Z).Equal(t2.Mul(&P2.X, &P1.Z))
@@ -80,7 +80,7 @@ func (P1 *projPoint) Equal(CP2 abstract.Point) bool {
 	return xeq && yeq
 }
 
-func (P *projPoint) Set(CP2 abstract.Point) abstract.Point {
+func (P *projPoint) Set(CP2 *abstract.Point) *abstract.Point {
 	P2 := CP2.(*projPoint)
 	P.c = P2.c
 	P.X.Set(&P2.X)
@@ -89,12 +89,12 @@ func (P *projPoint) Set(CP2 abstract.Point) abstract.Point {
 	return P
 }
 
-func (P *projPoint) Null() abstract.Point {
+func (P *projPoint) Null() *abstract.Point {
 	P.Set(&P.c.null)
 	return P
 }
 
-func (P *projPoint) Base() abstract.Point {
+func (P *projPoint) Base() *abstract.Point {
 	P.Set(&P.c.base)
 	return P
 }
@@ -111,7 +111,7 @@ func (P *projPoint) normalize() {
 	P.Z.V.SetInt64(1)
 }
 
-func (P *projPoint) Pick(data []byte, rand cipher.Stream) (abstract.Point, []byte) {
+func (P *projPoint) Pick(data []byte, rand cipher.Stream) (*abstract.Point, []byte) {
 	return P, P.c.pickPoint(P, data, rand)
 }
 
@@ -127,7 +127,7 @@ func (P *projPoint) Data() ([]byte, error) {
 //	http://eprint.iacr.org/2008/013.pdf
 //	https://hyperelliptic.org/EFD/g1p/auto-twisted-projective.html
 //
-func (P *projPoint) Add(CP1, CP2 abstract.Point) abstract.Point {
+func (P *projPoint) Add(CP1, CP2 *abstract.Point) *abstract.Point {
 	P1 := CP1.(*projPoint)
 	P2 := CP2.(*projPoint)
 	X1, Y1, Z1 := &P1.X, &P1.Y, &P1.Z
@@ -150,7 +150,7 @@ func (P *projPoint) Add(CP1, CP2 abstract.Point) abstract.Point {
 }
 
 // Subtract points so that their secrets subtract homomorphically
-func (P *projPoint) Sub(CP1, CP2 abstract.Point) abstract.Point {
+func (P *projPoint) Sub(CP1, CP2 *abstract.Point) *abstract.Point {
 	P1 := CP1.(*projPoint)
 	P2 := CP2.(*projPoint)
 	X1, Y1, Z1 := &P1.X, &P1.Y, &P1.Z
@@ -174,7 +174,7 @@ func (P *projPoint) Sub(CP1, CP2 abstract.Point) abstract.Point {
 
 // Find the negative of point A.
 // For Edwards curves, the negative of (x,y) is (-x,y).
-func (P *projPoint) Neg(CA abstract.Point) abstract.Point {
+func (P *projPoint) Neg(CA *abstract.Point) *abstract.Point {
 	A := CA.(*projPoint)
 	P.c = A.c
 	P.X.Neg(&A.X)
@@ -200,7 +200,7 @@ func (P *projPoint) double() {
 }
 
 // Multiply point p by scalar s using the repeated doubling method.
-func (P *projPoint) Mul(G abstract.Point, s abstract.Secret) abstract.Point {
+func (P *projPoint) Mul(G *abstract.Point, s *abstract.Secret) *abstract.Point {
 	v := s.(*nist.Int).V
 	if G == nil {
 		return P.Base().Mul(P, s)
@@ -237,7 +237,7 @@ type ProjectiveCurve struct {
 }
 
 // Create a new Point on this curve.
-func (c *ProjectiveCurve) Point() abstract.Point {
+func (c *ProjectiveCurve) Point() *abstract.Point {
 	P := new(projPoint)
 	P.c = c
 	//P.Set(&c.null)

--- a/enc_test.go
+++ b/enc_test.go
@@ -6,8 +6,8 @@ import (
 	"github.com/dedis/crypto/random"
 )
 
-func ElGamalEncrypt(suite abstract.Suite, pubkey abstract.Point, message []byte) (
-	K, C abstract.Point, remainder []byte) {
+func ElGamalEncrypt(suite abstract.Suite, pubkey *abstract.Point, message []byte) (
+	K, C *abstract.Point, remainder []byte) {
 
 	// Embed the message (or as much of it as will fit) into a curve point.
 	M, remainder := suite.Point().Pick(message, random.Stream)
@@ -20,7 +20,7 @@ func ElGamalEncrypt(suite abstract.Suite, pubkey abstract.Point, message []byte)
 	return
 }
 
-func ElGamalDecrypt(suite abstract.Suite, prikey abstract.Secret, K, C abstract.Point) (
+func ElGamalDecrypt(suite abstract.Suite, prikey *abstract.Secret, K, C *abstract.Point) (
 	message []byte, err error) {
 
 	// ElGamal-decrypt the ciphertext (K,C) to reproduce the message.

--- a/group/encoding.go
+++ b/group/encoding.go
@@ -4,7 +4,6 @@ package group
 
 import (
 	"crypto/cipher"
-	"fmt"
 	"github.com/dedis/crypto/abstract"
 	"io"
 )
@@ -12,7 +11,6 @@ import (
 // PointEncodeTo provides a generic implementation of Point.EncodeTo
 // based on Point.Encode.
 func PointMarshalTo(p *abstract.Point, w io.Writer) (int, error) {
-	fmt.Println("PointMarshalTo")
 	buf, err := p.MarshalBinary()
 	if err != nil {
 		return 0, err

--- a/group/encoding.go
+++ b/group/encoding.go
@@ -10,7 +10,7 @@ import (
 
 // PointEncodeTo provides a generic implementation of Point.EncodeTo
 // based on Point.Encode.
-func PointMarshalTo(p abstract.Point, w io.Writer) (int, error) {
+func PointMarshalTo(p *abstract.Point, w io.Writer) (int, error) {
 	buf, err := p.MarshalBinary()
 	if err != nil {
 		return 0, err
@@ -22,7 +22,7 @@ func PointMarshalTo(p abstract.Point, w io.Writer) (int, error) {
 // based on Point.Decode, or Point.Pick if r is a Cipher or cipher.Stream.
 // The returned byte-count is valid only when decoding from a normal Reader,
 // not when picking from a pseudorandom source.
-func PointUnmarshalFrom(p abstract.Point, r io.Reader) (int, error) {
+func PointUnmarshalFrom(p *abstract.Point, r io.Reader) (int, error) {
 	if strm, ok := r.(cipher.Stream); ok {
 		p.Pick(nil, strm)
 		return -1, nil // no byte-count when picking randomly
@@ -37,7 +37,7 @@ func PointUnmarshalFrom(p abstract.Point, r io.Reader) (int, error) {
 
 // SecretEncodeTo provides a generic implementation of Secret.EncodeTo
 // based on Secret.Encode.
-func SecretMarshalTo(s abstract.Secret, w io.Writer) (int, error) {
+func SecretMarshalTo(s *abstract.Secret, w io.Writer) (int, error) {
 	buf, err := s.MarshalBinary()
 	if err != nil {
 		return 0, err
@@ -49,7 +49,7 @@ func SecretMarshalTo(s abstract.Secret, w io.Writer) (int, error) {
 // based on Secret.Decode, or Secret.Pick if r is a Cipher or cipher.Stream.
 // The returned byte-count is valid only when decoding from a normal Reader,
 // not when picking from a pseudorandom source.
-func SecretUnmarshalFrom(s abstract.Secret, r io.Reader) (int, error) {
+func SecretUnmarshalFrom(s *abstract.Secret, r io.Reader) (int, error) {
 	if strm, ok := r.(cipher.Stream); ok {
 		s.Pick(strm)
 		return -1, nil // no byte-count when picking randomly

--- a/group/encoding.go
+++ b/group/encoding.go
@@ -4,6 +4,7 @@ package group
 
 import (
 	"crypto/cipher"
+	"fmt"
 	"github.com/dedis/crypto/abstract"
 	"io"
 )
@@ -11,6 +12,7 @@ import (
 // PointEncodeTo provides a generic implementation of Point.EncodeTo
 // based on Point.Encode.
 func PointMarshalTo(p *abstract.Point, w io.Writer) (int, error) {
+	fmt.Println("PointMarshalTo")
 	buf, err := p.MarshalBinary()
 	if err != nil {
 		return 0, err

--- a/math/jacobi.go
+++ b/math/jacobi.go
@@ -6,13 +6,13 @@ import (
 
 // Compute the Jacobi symbol of (x/y) using Euclid's algorithm.
 // This is usually much faster modular multiplication via Euler's criterion.
-func Jacobi(x,y *big.Int) int {
+func Jacobi(x, y *big.Int) int {
 
 	// We use the formulation described in chapter 2, section 2.4,
 	// "The Yacas Book of Algorithms":
 	// http://yacas.sourceforge.net/Algo.book.pdf
 
-	var a,b,c big.Int
+	var a, b, c big.Int
 	a.Set(x)
 	b.Set(y)
 	j := 1
@@ -23,27 +23,26 @@ func Jacobi(x,y *big.Int) int {
 		if b.Cmp(one) == 0 {
 			return j
 		}
-		a.Mod(&a,&b)
+		a.Mod(&a, &b)
 
 		// Handle factors of 2 in a
 		s := 0
 		for a.Bit(s) == 0 {
 			s++
 		}
-		if s & 1 != 0 {
+		if s&1 != 0 {
 			bmod8 := b.Bits()[0] & 7
 			if bmod8 == 3 || bmod8 == 5 {
 				j = -j
 			}
 		}
-		c.Rsh(&a,uint(s))			// a = 2^s*c
+		c.Rsh(&a, uint(s)) // a = 2^s*c
 
 		// Swap numerator and denominator
-		if b.Bits()[0] & 3 == 3 && c.Bits()[0] & 3 == 3 {
+		if b.Bits()[0]&3 == 3 && c.Bits()[0]&3 == 3 {
 			j = -j
 		}
 		a.Set(&b)
 		b.Set(&c)
 	}
 }
-

--- a/math/sqrt.go
+++ b/math/sqrt.go
@@ -16,43 +16,43 @@ var two = big.NewInt(2)
 func Sqrt(z *big.Int, a *big.Int, p *big.Int) bool {
 
 	if a.Sign() == 0 {
-		z.SetInt64(0)		// sqrt(0) = 0
+		z.SetInt64(0) // sqrt(0) = 0
 		return true
 	}
-	if Jacobi(a,p) != 1 {
-		return false		// a is not a square mod M
+	if Jacobi(a, p) != 1 {
+		return false // a is not a square mod M
 	}
 
 	// Break p-1 into s*2^e such that s is odd.
 	var s big.Int
 	var e int
-	s.Sub(p,one)
+	s.Sub(p, one)
 	for s.Bit(0) == 0 {
-		s.Div(&s,two)
+		s.Div(&s, two)
 		e++
 	}
 
 	// Find some non-square n
 	var n big.Int
 	n.SetInt64(2)
-	for Jacobi(&n,p) != -1 {
-		n.Add(&n,one)
+	for Jacobi(&n, p) != -1 {
+		n.Add(&n, one)
 	}
 
 	// Heart of the Tonelli-Shanks algorithm.
 	// Follows the description in
 	// "Square roots from 1; 24, 51, 10 to Dan Shanks" by Ezra Brown.
-	var x,b,g,t big.Int
-	x.Add(&s,one).Div(&x,two).Exp(a,&x,p)
-	b.Exp(a,&s,p)
-	g.Exp(&n,&s,p)
+	var x, b, g, t big.Int
+	x.Add(&s, one).Div(&x, two).Exp(a, &x, p)
+	b.Exp(a, &s, p)
+	g.Exp(&n, &s, p)
 	r := e
 	for {
 		// Find the least m such that ord_p(b) = 2^m
 		var m int
 		t.Set(&b)
 		for t.Cmp(one) != 0 {
-			t.Exp(&t,two,p)
+			t.Exp(&t, two, p)
 			m++
 		}
 
@@ -61,12 +61,11 @@ func Sqrt(z *big.Int, a *big.Int, p *big.Int) bool {
 			return true
 		}
 
-		t.SetInt64(0).SetBit(&t,r-m-1,1).Exp(&g,&t,p)
-					// t = g^(2^(r-m-1)) mod p
-		g.Mul(&t,&t).Mod(&g,p)	// g = g^(2^(r-m)) mod p
-		x.Mul(&x,&t).Mod(&x,p)
-		b.Mul(&b,&g).Mod(&b,p)
+		t.SetInt64(0).SetBit(&t, r-m-1, 1).Exp(&g, &t, p)
+		// t = g^(2^(r-m-1)) mod p
+		g.Mul(&t, &t).Mod(&g, p) // g = g^(2^(r-m)) mod p
+		x.Mul(&x, &t).Mod(&x, p)
+		b.Mul(&b, &g).Mod(&b, p)
 		r = m
 	}
 }
-

--- a/nego/bits.go
+++ b/nego/bits.go
@@ -9,7 +9,7 @@ import (
 // for the first bit with value b.
 // Returns the position of the first b-bit found,
 // or -1 if every bit in the bit-field is set to 1-b.
-func BitScan(x *big.Int, i,j int, b uint) int {
+func BitScan(x *big.Int, i, j int, b uint) int {
 
 	// XXX could be made a lot more efficient using x.Words()
 	inc := 1
@@ -26,7 +26,7 @@ func BitScan(x *big.Int, i,j int, b uint) int {
 
 // Set z to x, but with the bit-field from bit i
 // up or down to bit j filled with bit value b.
-func BitFill(z,x *big.Int, i,j int, b uint) {
+func BitFill(z, x *big.Int, i, j int, b uint) {
 	if z != x {
 		z.Set(x)
 	}
@@ -38,4 +38,3 @@ func BitFill(z,x *big.Int, i,j int, b uint) {
 		z.SetBit(z, i, b)
 	}
 }
-

--- a/nego/byte.go
+++ b/nego/byte.go
@@ -1,6 +1,5 @@
 package nego
 
-
 // Simple reservation byte-mask layout
 type byteLayout struct {
 	mask []byte
@@ -10,7 +9,7 @@ func (bl *byteLayout) init(max int) {
 	bl.mask = make([]byte, max)
 }
 
-func (bl *byteLayout) reserve(lo,hi int, excl bool, obj interface{}) bool {
+func (bl *byteLayout) reserve(lo, hi int, excl bool, obj interface{}) bool {
 	max := len(bl.mask)
 	if hi > max {
 		hi = max
@@ -35,4 +34,3 @@ func (bl *byteLayout) reserve(lo,hi int, excl bool, obj interface{}) bool {
 	}
 	return gotExcl
 }
-

--- a/nego/nego.go
+++ b/nego/nego.go
@@ -19,7 +19,7 @@ import (
 
 type Entry struct {
 	Suite  abstract.Suite // Ciphersuite this public key is drawn from
-	PubKey abstract.Point // Public key of this entrypoint's owner
+	PubKey *abstract.Point // Public key of this entrypoint's owner
 	Data   []byte         // Entrypoint data decryptable by owner
 }
 
@@ -32,8 +32,8 @@ type suiteKey struct {
 
 	// Ephemeral Diffie-Hellman key for all key-holders using this suite.
 	// Should have a uniform representation, e.g., an Elligator point.
-	dhpri abstract.Secret
-	dhpub abstract.Point
+	dhpri *abstract.Secret
+	dhpub *abstract.Point
 	dhrep []byte
 }
 
@@ -56,7 +56,7 @@ type suiteInfo struct {
 	// layout info
 	//nodes []*node			// layout node for reserved positions
 	lev int             // layout-chosen level for this suite
-	pri abstract.Secret // ephemeral Diffie-Hellman private key
+	pri *abstract.Secret // ephemeral Diffie-Hellman private key
 	pub []byte          // corresponding encoded public key
 }
 

--- a/nego/nego.go
+++ b/nego/nego.go
@@ -18,9 +18,9 @@ import (
 )
 
 type Entry struct {
-	Suite  abstract.Suite // Ciphersuite this public key is drawn from
+	Suite  abstract.Suite  // Ciphersuite this public key is drawn from
 	PubKey *abstract.Point // Public key of this entrypoint's owner
-	Data   []byte         // Entrypoint data decryptable by owner
+	Data   []byte          // Entrypoint data decryptable by owner
 }
 
 func (e *Entry) String() string {
@@ -55,9 +55,9 @@ type suiteInfo struct {
 
 	// layout info
 	//nodes []*node			// layout node for reserved positions
-	lev int             // layout-chosen level for this suite
+	lev int              // layout-chosen level for this suite
 	pri *abstract.Secret // ephemeral Diffie-Hellman private key
-	pub []byte          // corresponding encoded public key
+	pub []byte           // corresponding encoded public key
 }
 
 func (si *suiteInfo) String() string {

--- a/nego/nego_test.go
+++ b/nego/nego_test.go
@@ -2,10 +2,10 @@ package nego
 
 import (
 	"fmt"
-	"testing"
 	"github.com/dedis/crypto/abstract"
-	"github.com/dedis/crypto/random"
 	"github.com/dedis/crypto/edwards"
+	"github.com/dedis/crypto/random"
+	"testing"
 )
 
 // Simple harness to create lots of fake ciphersuites out of a few real ones,
@@ -19,19 +19,18 @@ func (f *fakeSuite) String() string {
 	return fmt.Sprintf("%s(%d)", f.Suite.String(), f.idx)
 }
 
-
 func TestNego(t *testing.T) {
 
 	realSuites := []abstract.Suite{
-			edwards.NewAES128SHA256Ed25519(true),
-		}
+		edwards.NewAES128SHA256Ed25519(true),
+	}
 
 	fakery := 10
 	nentries := 10
 	datalen := 16
 
 	suites := make([]abstract.Suite, 0)
-	for i := range(realSuites) {
+	for i := range realSuites {
 		real := realSuites[i]
 		for j := 0; j < fakery; j++ {
 			suites = append(suites, &fakeSuite{real, j})
@@ -41,9 +40,9 @@ func TestNego(t *testing.T) {
 	nlevels := 5
 	suiteLevel := make(map[abstract.Suite]int)
 	entries := make([]Entry, 0)
-	for i := range(suites) {
+	for i := range suites {
 		suiteLevel[suites[i]] = nlevels
-		nlevels++			// vary it a bit for testing
+		nlevels++ // vary it a bit for testing
 
 		// Create some entrypoints with this suite
 		s := suites[i]
@@ -51,15 +50,14 @@ func TestNego(t *testing.T) {
 			pri := s.Secret().Pick(random.Stream)
 			pub := s.Point().Mul(nil, pri)
 			data := make([]byte, datalen)
-			entries = append(entries, Entry{s,pub,data})
+			entries = append(entries, Entry{s, pub, data})
 		}
 	}
 
 	w := Writer{}
-	_,err := w.Layout(suiteLevel, entries, nil)
+	_, err := w.Layout(suiteLevel, entries, nil)
 	if err != nil {
 		t.Log(err)
 		t.FailNow()
 	}
 }
-

--- a/nego/skip.go
+++ b/nego/skip.go
@@ -5,7 +5,6 @@ import (
 	"github.com/dedis/crypto/random"
 )
 
-
 // Pick a uint32 uniformly at random
 func randUint32() uint32 {
 	return random.Uint32(random.Stream)
@@ -14,16 +13,16 @@ func randUint32() uint32 {
 // Pick a random height for a new skip-list node from a suitable distribution.
 func skipHeight() int {
 	height := 1
-	for v := randUint32() | (1<<31); v & 1 == 0; v >>= 1 {
+	for v := randUint32() | (1 << 31); v&1 == 0; v >>= 1 {
 		height++
 	}
 	return height
 }
 
 type skipNode struct {
-	lo,hi int
-	suc []*skipNode
-	name string
+	lo, hi int
+	suc    []*skipNode
+	name   string
 }
 
 // Skip-list reservation structure.
@@ -34,14 +33,14 @@ type skipLayout struct {
 }
 
 func (sl *skipLayout) reset() {
-	sl.head = make([]*skipNode, 1)		// minimum stack height
+	sl.head = make([]*skipNode, 1) // minimum stack height
 }
 
 // Create a new skip-list iterator.
 // An iterator is a stack of pointers to next pointers, one per level.
 func (sl *skipLayout) iter() []**skipNode {
 	pos := make([]**skipNode, len(sl.head))
-	for i := range(pos) {
+	for i := range pos {
 		pos[i] = &sl.head[i]
 	}
 	return pos
@@ -50,7 +49,7 @@ func (sl *skipLayout) iter() []**skipNode {
 // Advance a position vector past a given node,
 // which must be pointed to by one of the current position pointers.
 func (sl *skipLayout) skip(pos []**skipNode, past *skipNode) {
-	for i := range(past.suc) {
+	for i := range past.suc {
 		pos[i] = &past.suc[i]
 	}
 }
@@ -58,7 +57,7 @@ func (sl *skipLayout) skip(pos []**skipNode, past *skipNode) {
 // Find the position past all nodes strictly before byte offset ofs.
 func (sl *skipLayout) find(ofs int) []**skipNode {
 	pos := sl.iter()
-	for i := len(pos)-1; i >= 0; i-- {
+	for i := len(pos) - 1; i >= 0; i-- {
 		for n := *pos[i]; n != nil && n.hi <= ofs; n = *pos[i] {
 			// Advance past n at all levels up through i
 			sl.skip(pos, n)
@@ -69,14 +68,14 @@ func (sl *skipLayout) find(ofs int) []**skipNode {
 
 // Insert a new node at a given iterator position, and skip past it.
 // May extend the iterator slice, so returns a new position slice.
-func (sl *skipLayout) insert(pos []**skipNode, lo,hi int,
-				name string) []**skipNode {
+func (sl *skipLayout) insert(pos []**skipNode, lo, hi int,
+	name string) []**skipNode {
 
-	nsuc := make([]*skipNode,skipHeight())
-	n := skipNode{lo,hi,nsuc,name}
+	nsuc := make([]*skipNode, skipHeight())
+	n := skipNode{lo, hi, nsuc, name}
 
 	// Insert the new node at all appropriate levels
-	for i := range(nsuc) {
+	for i := range nsuc {
 		if i == len(pos) {
 			// base node's stack not high enough, extend it
 			sl.head = append(sl.head, nil)
@@ -93,7 +92,7 @@ func (sl *skipLayout) insert(pos []**skipNode, lo,hi int,
 // If excl is true, either reserve it exclusively or fail without modification.
 // If excl is false, reserve region even if some or all of it already reserved.
 // Returns true if requested region was reserved exclusively, false if not.
-func (sl *skipLayout) reserve(lo,hi int, excl bool, name string) bool {
+func (sl *skipLayout) reserve(lo, hi int, excl bool, name string) bool {
 
 	// Find the position past all nodes strictly before our interest area
 	pos := sl.find(lo)
@@ -101,9 +100,9 @@ func (sl *skipLayout) reserve(lo,hi int, excl bool, name string) bool {
 	// Can we get an exclusive reservation?
 	suc := *pos[0]
 	gotExcl := true
-	if suc != nil && suc.lo < hi {		// suc overlaps what we want?
+	if suc != nil && suc.lo < hi { // suc overlaps what we want?
 		if excl {
-			return false		// excl required but can't get
+			return false // excl required but can't get
 		}
 		gotExcl = false
 	}
@@ -121,7 +120,7 @@ func (sl *skipLayout) reserve(lo,hi int, excl bool, name string) bool {
 		// How big of a reservation can we insert here?
 		inshi := hi
 		if suc != nil && suc.lo < inshi {
-			inshi = suc.lo	// end at start of next existing region
+			inshi = suc.lo // end at start of next existing region
 		}
 		if lo >= inshi {
 			panic("trying to insert empty reservation")
@@ -141,14 +140,14 @@ func (sl *skipLayout) alloc(l int, name string) int {
 
 	pos := sl.iter()
 	ofs := 0
-	for {	// Find a position to insert
+	for { // Find a position to insert
 		suc := *pos[0]
 		if suc == nil {
-			break	// no more reservations; definitely room here!
+			break // no more reservations; definitely room here!
 		}
 		avail := suc.lo - ofs
 		if avail >= l {
-			break	// there's enough room here
+			break // there's enough room here
 		}
 		sl.skip(pos, suc)
 		ofs = suc.hi
@@ -161,14 +160,14 @@ func (sl *skipLayout) alloc(l int, name string) int {
 
 // Call the supplied function on every free region in the layout,
 // up to a given maximum byte offset.
-func (sl *skipLayout) scanFree(f func(int,int), max int) {
+func (sl *skipLayout) scanFree(f func(int, int), max int) {
 
 	pos := sl.iter()
 	ofs := 0
 	for {
 		suc := *pos[0]
 		if suc == nil {
-			break	// no more reservations
+			break // no more reservations
 		}
 		if suc.lo > ofs {
 			f(ofs, suc.lo)
@@ -177,7 +176,7 @@ func (sl *skipLayout) scanFree(f func(int,int), max int) {
 		ofs = suc.hi
 	}
 	if ofs < max {
-		f(ofs,max)
+		f(ofs, max)
 	}
 }
 
@@ -185,14 +184,14 @@ func (sl *skipLayout) dump() {
 
 	pos := make([]**skipNode, len(sl.head))
 	//fmt.Printf("Skip-list levels: %d\n", len(pos))
-	for i := range(pos) {
+	for i := range pos {
 		pos[i] = &sl.head[i]
 		//fmt.Printf(" H%d: %p\n", i, *pos[i])
 	}
 	for n := *pos[0]; n != nil; n = *pos[0] {
 		fmt.Printf("%p [%d-%d] level %d: %s\n",
-				n, n.lo, n.hi, len(n.suc), n.name)
-		for j := range(n.suc) {		// skip-list invariant check
+			n, n.lo, n.hi, len(n.suc), n.name)
+		for j := range n.suc { // skip-list invariant check
 			//fmt.Printf(" S%d: %p\n", j, n.suc[j])
 			if *pos[j] != n {
 				panic("bad suc pointer")
@@ -200,11 +199,10 @@ func (sl *skipLayout) dump() {
 			pos[j] = &n.suc[j]
 		}
 	}
-	for i := range(pos) {
+	for i := range pos {
 		n := *pos[i]
 		if n != nil {
-			panic("orphaned skip-node: "+n.name)
+			panic("orphaned skip-node: " + n.name)
 		}
 	}
 }
-

--- a/nist/curve.go
+++ b/nist/curve.go
@@ -22,7 +22,7 @@ func (p *curvePoint) String() string {
 	return "(" + p.x.String() + "," + p.y.String() + ")"
 }
 
-func (p *curvePoint) Equal(p2 abstract.Point) bool {
+func (p *curvePoint) Equal(p2 *abstract.Point) bool {
 	cp2 := p2.(*curvePoint)
 
 	// Make sure both coordinates are normalized.
@@ -36,13 +36,13 @@ func (p *curvePoint) Equal(p2 abstract.Point) bool {
 	return p.x.Cmp(cp2.x) == 0 && p.y.Cmp(cp2.y) == 0
 }
 
-func (p *curvePoint) Null() abstract.Point {
+func (p *curvePoint) Null() *abstract.Point {
 	p.x = new(big.Int).SetInt64(0)
 	p.y = new(big.Int).SetInt64(0)
 	return p
 }
 
-func (p *curvePoint) Base() abstract.Point {
+func (p *curvePoint) Base() *abstract.Point {
 	p.x = p.c.p.Gx
 	p.y = p.c.p.Gy
 	return p
@@ -99,7 +99,7 @@ func (p *curvePoint) PickLen() int {
 
 // Pick a curve point containing a variable amount of embedded data.
 // Remaining bits comprising the point are chosen randomly.
-func (p *curvePoint) Pick(data []byte, rand cipher.Stream) (abstract.Point, []byte) {
+func (p *curvePoint) Pick(data []byte, rand cipher.Stream) (*abstract.Point, []byte) {
 
 	l := p.c.coordLen()
 	dl := p.PickLen()
@@ -133,14 +133,14 @@ func (p *curvePoint) Data() ([]byte, error) {
 	return b[l-dl-1 : l-1], nil
 }
 
-func (p *curvePoint) Add(a, b abstract.Point) abstract.Point {
+func (p *curvePoint) Add(a, b *abstract.Point) *abstract.Point {
 	ca := a.(*curvePoint)
 	cb := b.(*curvePoint)
 	p.x, p.y = p.c.Add(ca.x, ca.y, cb.x, cb.y)
 	return p
 }
 
-func (p *curvePoint) Sub(a, b abstract.Point) abstract.Point {
+func (p *curvePoint) Sub(a, b *abstract.Point) *abstract.Point {
 	ca := a.(*curvePoint)
 	cb := b.(*curvePoint)
 
@@ -150,7 +150,7 @@ func (p *curvePoint) Sub(a, b abstract.Point) abstract.Point {
 	return p
 }
 
-func (p *curvePoint) Neg(a abstract.Point) abstract.Point {
+func (p *curvePoint) Neg(a *abstract.Point) *abstract.Point {
 
 	// XXX a pretty non-optimal implementation of point negation...
 	s := p.c.Secret().One()
@@ -158,7 +158,7 @@ func (p *curvePoint) Neg(a abstract.Point) abstract.Point {
 	return p.Mul(a, s).(*curvePoint)
 }
 
-func (p *curvePoint) Mul(b abstract.Point, s abstract.Secret) abstract.Point {
+func (p *curvePoint) Mul(b *abstract.Point, s *abstract.Secret) *abstract.Point {
 	cs := s.(*Int)
 	if b != nil {
 		cb := b.(*curvePoint)
@@ -229,7 +229,7 @@ func (g *curve) PrimeOrder() bool {
 func (c *curve) SecretLen() int { return (c.p.N.BitLen() + 7) / 8 }
 
 // Create a Secret associated with this curve.
-func (c *curve) Secret() abstract.Secret {
+func (c *curve) Secret() *abstract.Secret {
 	return NewInt(0, c.p.N)
 }
 
@@ -246,7 +246,7 @@ func (c *curve) PointLen() int {
 }
 
 // Create a Point associated with this curve.
-func (c *curve) Point() abstract.Point {
+func (c *curve) Point() *abstract.Point {
 	p := new(curvePoint)
 	p.c = c
 	return p

--- a/nist/curve.go
+++ b/nist/curve.go
@@ -2,7 +2,6 @@ package nist
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"math/big"
 	//"encoding/hex"
@@ -176,12 +175,10 @@ func (p *curvePoint) MarshalSize() int {
 }
 
 func (p *curvePoint) MarshalBinary() ([]byte, error) {
-	fmt.Println("MarshalBinary cp")
 	return elliptic.Marshal(p.c, p.x, p.y), nil
 }
 
 func (p *curvePoint) UnmarshalBinary(buf []byte) error {
-	fmt.Println("Unmarshal curvepoint")
 	// Check whether all bytes after first one are 0, so we
 	// just return the initial point. Read everything to
 	// prevent timing-leakage.
@@ -203,12 +200,10 @@ func (p *curvePoint) UnmarshalBinary(buf []byte) error {
 }
 
 func (p *curvePoint) MarshalTo(w io.Writer) (int, error) {
-	fmt.Println("MarshalTo cp")
 	return group.PointMarshalTo(p.MakePoint(p), w)
 }
 
 func (p *curvePoint) UnmarshalFrom(r io.Reader) (int, error) {
-	fmt.Println("Unmarshalfrom curvepoint")
 	return group.PointUnmarshalFrom(p.MakePoint(p), r)
 }
 
@@ -238,7 +233,7 @@ func (c *curve) SecretLen() int { return (c.p.N.BitLen() + 7) / 8 }
 func (c *curve) Secret() *abstract.Secret {
 	s := NewInt(0, c.p.N)
 	s.Suite = c.name
-	return s.MakeSecret(s)
+	return s.Secret()
 }
 
 // Number of bytes required to store one coordinate on this curve
@@ -257,7 +252,7 @@ func (c *curve) PointLen() int {
 func (c *curve) Point() *abstract.Point {
 	p := new(curvePoint)
 	p.c = c
-	p.Suite = c.name
+	p.Payload = &abstract.Payload{Suite: c.name}
 	return p.MakePoint(p)
 }
 

--- a/nist/int.go
+++ b/nist/int.go
@@ -20,8 +20,8 @@ var two = big.NewInt(2)
 // Int is a generic implementation of finite field arithmetic
 // on integer finite fields with a given constant modulus,
 // built using Go's built-in big.Int package.
-// Int satisfies the abstract abstract.Secret interface,
-// and hence serves as a basic implementation of abstract.Secret,
+// Int satisfies the abstract *abstract.Secret interface,
+// and hence serves as a basic implementation of *abstract.Secret,
 // e.g., representing discrete-log exponents of Schnorr groups
 // or scalar multipliers for elliptic curves.
 //
@@ -103,12 +103,12 @@ func (i *Int) SetString(n, d string, base int) (*Int, bool) {
 }
 
 // Compare two Ints for equality or inequality
-func (i *Int) Cmp(s2 abstract.Secret) int {
+func (i *Int) Cmp(s2 *abstract.Secret) int {
 	return i.V.Cmp(&s2.(*Int).V)
 }
 
 // Test two Ints for equality
-func (i *Int) Equal(s2 abstract.Secret) bool {
+func (i *Int) Equal(s2 *abstract.Secret) bool {
 	return i.V.Cmp(&s2.(*Int).V) == 0
 }
 
@@ -120,7 +120,7 @@ func (i *Int) Nonzero() bool {
 // Set both value and modulus to be equal to another Int.
 // Since this method copies the modulus as well,
 // it may be used as an alternative to Init().
-func (i *Int) Set(a abstract.Secret) abstract.Secret {
+func (i *Int) Set(a *abstract.Secret) *abstract.Secret {
 	ai := a.(*Int)
 	i.V.Set(&ai.V)
 	i.M = ai.M
@@ -142,20 +142,20 @@ func (i *Int) SetLittleEndian(a []byte) *Int {
 }
 
 // Set to the value 0.  The modulus must already be initialized.
-func (i *Int) Zero() abstract.Secret {
+func (i *Int) Zero() *abstract.Secret {
 	i.V.SetInt64(0)
 	return i
 }
 
 // Set to the value 1.  The modulus must already be initialized.
-func (i *Int) One() abstract.Secret {
+func (i *Int) One() *abstract.Secret {
 	i.V.SetInt64(1)
 	return i
 }
 
 // Set to an arbitrary 64-bit "small integer" value.
 // The modulus must already be initialized.
-func (i *Int) SetInt64(v int64) abstract.Secret {
+func (i *Int) SetInt64(v int64) *abstract.Secret {
 	i.V.SetInt64(v).Mod(&i.V, i.M)
 	return i
 }
@@ -168,7 +168,7 @@ func (i *Int) Int64() int64 {
 
 // Set to an arbitrary uint64 value.
 // The modulus must already be initialized.
-func (i *Int) SetUint64(v uint64) abstract.Secret {
+func (i *Int) SetUint64(v uint64) *abstract.Secret {
 	i.V.SetUint64(v).Mod(&i.V, i.M)
 	return i
 }
@@ -180,7 +180,7 @@ func (i *Int) Uint64() uint64 {
 }
 
 // Set target to a + b mod M, where M is a's modulus..
-func (i *Int) Add(a, b abstract.Secret) abstract.Secret {
+func (i *Int) Add(a, b *abstract.Secret) *abstract.Secret {
 	ai := a.(*Int)
 	bi := b.(*Int)
 	i.M = ai.M
@@ -190,7 +190,7 @@ func (i *Int) Add(a, b abstract.Secret) abstract.Secret {
 
 // Set target to a - b mod M.
 // Target receives a's modulus.
-func (i *Int) Sub(a, b abstract.Secret) abstract.Secret {
+func (i *Int) Sub(a, b *abstract.Secret) *abstract.Secret {
 	ai := a.(*Int)
 	bi := b.(*Int)
 	i.M = ai.M
@@ -199,7 +199,7 @@ func (i *Int) Sub(a, b abstract.Secret) abstract.Secret {
 }
 
 // Set to -a mod M.
-func (i *Int) Neg(a abstract.Secret) abstract.Secret {
+func (i *Int) Neg(a *abstract.Secret) *abstract.Secret {
 	ai := a.(*Int)
 	i.M = ai.M
 	if ai.V.Sign() > 0 {
@@ -212,7 +212,7 @@ func (i *Int) Neg(a abstract.Secret) abstract.Secret {
 
 // Set to a * b mod M.
 // Target receives a's modulus.
-func (i *Int) Mul(a, b abstract.Secret) abstract.Secret {
+func (i *Int) Mul(a, b *abstract.Secret) *abstract.Secret {
 	ai := a.(*Int)
 	bi := b.(*Int)
 	i.M = ai.M
@@ -221,7 +221,7 @@ func (i *Int) Mul(a, b abstract.Secret) abstract.Secret {
 }
 
 // Set to a * b^-1 mod M, where b^-1 is the modular inverse of b.
-func (i *Int) Div(a, b abstract.Secret) abstract.Secret {
+func (i *Int) Div(a, b *abstract.Secret) *abstract.Secret {
 	ai := a.(*Int)
 	bi := b.(*Int)
 	var t big.Int
@@ -232,7 +232,7 @@ func (i *Int) Div(a, b abstract.Secret) abstract.Secret {
 }
 
 // Set to the modular inverse of a with respect to modulus M.
-func (i *Int) Inv(a abstract.Secret) abstract.Secret {
+func (i *Int) Inv(a *abstract.Secret) *abstract.Secret {
 	ai := a.(*Int)
 	i.M = ai.M
 	i.V.ModInverse(&a.(*Int).V, i.M)
@@ -241,7 +241,7 @@ func (i *Int) Inv(a abstract.Secret) abstract.Secret {
 
 // Set to a^e mod M,
 // where e is an arbitrary big.Int exponent (not necessarily 0 <= e < M).
-func (i *Int) Exp(a abstract.Secret, e *big.Int) abstract.Secret {
+func (i *Int) Exp(a *abstract.Secret, e *big.Int) *abstract.Secret {
 	ai := a.(*Int)
 	i.M = ai.M
 	i.V.Exp(&ai.V, e, i.M)
@@ -263,7 +263,7 @@ func (i *Int) legendre() int {
 
 // Set to the Jacobi symbol of (a/M), which indicates whether a is
 // zero (0), a positive square in M (1), or a non-square in M (-1).
-func (i *Int) Jacobi(as abstract.Secret) abstract.Secret {
+func (i *Int) Jacobi(as *abstract.Secret) *abstract.Secret {
 	ai := as.(*Int)
 	i.M = ai.M
 	i.V.SetInt64(int64(math.Jacobi(&ai.V, i.M)))
@@ -274,7 +274,7 @@ func (i *Int) Jacobi(as abstract.Secret) abstract.Secret {
 // Assumes the modulus M is an odd prime.
 // Returns true on success, false if input a is not a square.
 // (This really should be part of Go's big.Int library.)
-func (i *Int) Sqrt(as abstract.Secret) bool {
+func (i *Int) Sqrt(as *abstract.Secret) bool {
 	ai := as.(*Int)
 	i.M = ai.M
 	return math.Sqrt(&i.V, &ai.V, ai.M)
@@ -282,7 +282,7 @@ func (i *Int) Sqrt(as abstract.Secret) bool {
 
 // Pick a [pseudo-]random integer modulo M
 // using bits from the given stream cipher.
-func (i *Int) Pick(rand cipher.Stream) abstract.Secret {
+func (i *Int) Pick(rand cipher.Stream) *abstract.Secret {
 	i.V.Set(random.Int(i.M, rand))
 	return i
 }

--- a/nist/p256.go
+++ b/nist/p256.go
@@ -72,5 +72,6 @@ func (c *p256) Init() curve {
 	c.curve.Curve = elliptic.P256()
 	c.p = c.Params()
 	c.curveOps = c
+	c.name = c.String()
 	return c.curve
 }

--- a/nist/residue.go
+++ b/nist/residue.go
@@ -28,16 +28,16 @@ func isPrime(i *big.Int) bool {
 
 func (p *residuePoint) String() string { return p.Int.String() }
 
-func (p *residuePoint) Equal(p2 abstract.Point) bool {
+func (p *residuePoint) Equal(p2 *abstract.Point) bool {
 	return p.Int.Cmp(&p2.(*residuePoint).Int) == 0
 }
 
-func (p *residuePoint) Null() abstract.Point {
+func (p *residuePoint) Null() *abstract.Point {
 	p.Int.SetInt64(1)
 	return p
 }
 
-func (p *residuePoint) Base() abstract.Point {
+func (p *residuePoint) Base() *abstract.Point {
 	p.Int.Set(p.g.G)
 	return p
 }
@@ -56,7 +56,7 @@ func (p *residuePoint) PickLen() int {
 // Pick a point containing a variable amount of embedded data.
 // Remaining bits comprising the point are chosen randomly.
 // This will only work efficiently for quadratic residue groups!
-func (p *residuePoint) Pick(data []byte, rand cipher.Stream) (abstract.Point, []byte) {
+func (p *residuePoint) Pick(data []byte, rand cipher.Stream) (*abstract.Point, []byte) {
 
 	l := p.g.PointLen()
 	dl := p.PickLen()
@@ -92,25 +92,25 @@ func (p *residuePoint) Data() ([]byte, error) {
 	return b[l-dl-2 : l-2], nil
 }
 
-func (p *residuePoint) Add(a, b abstract.Point) abstract.Point {
+func (p *residuePoint) Add(a, b *abstract.Point) *abstract.Point {
 	p.Int.Mul(&a.(*residuePoint).Int, &b.(*residuePoint).Int)
 	p.Int.Mod(&p.Int, p.g.P)
 	return p
 }
 
-func (p *residuePoint) Sub(a, b abstract.Point) abstract.Point {
+func (p *residuePoint) Sub(a, b *abstract.Point) *abstract.Point {
 	binv := new(big.Int).ModInverse(&b.(*residuePoint).Int, p.g.P)
 	p.Int.Mul(&a.(*residuePoint).Int, binv)
 	p.Int.Mod(&p.Int, p.g.P)
 	return p
 }
 
-func (p *residuePoint) Neg(a abstract.Point) abstract.Point {
+func (p *residuePoint) Neg(a *abstract.Point) *abstract.Point {
 	p.Int.ModInverse(&a.(*residuePoint).Int, p.g.P)
 	return p
 }
 
-func (p *residuePoint) Mul(b abstract.Point, s abstract.Secret) abstract.Point {
+func (p *residuePoint) Mul(b *abstract.Point, s *abstract.Secret) *abstract.Point {
 	if b == nil {
 		return p.Base().Mul(p, s)
 	}
@@ -191,7 +191,7 @@ func (g *ResidueGroup) SecretLen() int { return (g.Q.BitLen() + 7) / 8 }
 
 // Create a Secret associated with this Residue group,
 // with an initial value of nil.
-func (g *ResidueGroup) Secret() abstract.Secret {
+func (g *ResidueGroup) Secret() *abstract.Secret {
 	return NewInt(0, g.Q)
 }
 
@@ -201,7 +201,7 @@ func (g *ResidueGroup) PointLen() int { return (g.P.BitLen() + 7) / 8 }
 
 // Create a Point associated with this Residue group,
 // with an initial value of nil.
-func (g *ResidueGroup) Point() abstract.Point {
+func (g *ResidueGroup) Point() *abstract.Point {
 	p := new(residuePoint)
 	p.g = g
 	return p

--- a/nist/suite.go
+++ b/nist/suite.go
@@ -9,6 +9,10 @@ import (
 	"reflect"
 )
 
+func init() {
+	abstract.AddSuite(NewAES128SHA256P256())
+}
+
 type suite128 struct {
 	p256
 }
@@ -39,5 +43,6 @@ func (s *suite128) New(t reflect.Type) interface{} {
 func NewAES128SHA256P256() abstract.Suite {
 	suite := new(suite128)
 	suite.p256.Init()
+	suite.name = suite.String()
 	return suite
 }

--- a/openssl/curve.go
+++ b/openssl/curve.go
@@ -66,7 +66,7 @@ func (p *point) String() string {
 func (p *point) Valid() bool {
 	return C.EC_POINT_is_on_curve(p.g, p.p, p.c.ctx) != 0
 }
-func (p *point) Equal(p2 abstract.Point) bool {
+func (p *point) Equal(p2 *abstract.Point) bool {
 	return C.EC_POINT_cmp(p.g, p.p, p2.(*point).p, p.c.ctx) == 0
 }
 func (p *point) GetX() *bignum {
@@ -86,14 +86,14 @@ func (p *point) GetY() *bignum {
 	return y
 }
 
-func (p *point) Null() abstract.Point {
+func (p *point) Null() *abstract.Point {
 	if C.EC_POINT_set_to_infinity(p.c.g, p.p) == 0 {
 		panic("EC_POINT_set_to_infinity: " + getErrString())
 	}
 	return p
 }
 
-func (p *point) Base() abstract.Point {
+func (p *point) Base() *abstract.Point {
 	genp := C.EC_GROUP_get0_generator(p.c.g)
 	if genp == nil {
 		panic("EC_GROUP_get0_generator: " + getErrString())
@@ -111,7 +111,7 @@ func (p *point) PickLen() int {
 	return (p.c.p.BitLen() - 8 - 8) / 8
 }
 
-func (p *point) Pick(data []byte, rand cipher.Stream) (abstract.Point, []byte) {
+func (p *point) Pick(data []byte, rand cipher.Stream) (*abstract.Point, []byte) {
 
 	l := p.c.PointLen()
 	dl := p.PickLen()
@@ -152,7 +152,7 @@ func (p *point) Data() ([]byte, error) {
 	return b[l-dl-1 : l-1], nil
 }
 
-func (p *point) Add(ca, cb abstract.Point) abstract.Point {
+func (p *point) Add(ca, cb *abstract.Point) *abstract.Point {
 	a := ca.(*point)
 	b := cb.(*point)
 	if C.EC_POINT_add(p.c.g, p.p, a.p, b.p, p.c.ctx) == 0 {
@@ -161,7 +161,7 @@ func (p *point) Add(ca, cb abstract.Point) abstract.Point {
 	return p
 }
 
-func (p *point) Sub(ca, cb abstract.Point) abstract.Point {
+func (p *point) Sub(ca, cb *abstract.Point) *abstract.Point {
 	a := ca.(*point)
 	b := cb.(*point)
 	// Add the point inverse.  Must use temporary if p == a.
@@ -181,7 +181,7 @@ func (p *point) Sub(ca, cb abstract.Point) abstract.Point {
 	return p
 }
 
-func (p *point) Neg(ca abstract.Point) abstract.Point {
+func (p *point) Neg(ca *abstract.Point) *abstract.Point {
 	if ca != p {
 		a := ca.(*point)
 		if C.EC_POINT_copy(p.p, a.p) == 0 {
@@ -194,7 +194,7 @@ func (p *point) Neg(ca abstract.Point) abstract.Point {
 	return p
 }
 
-func (p *point) Mul(cb abstract.Point, cs abstract.Secret) abstract.Point {
+func (p *point) Mul(cb *abstract.Point, cs *abstract.Secret) *abstract.Point {
 	s := cs.(*secret)
 	if cb == nil { // multiply standard generator
 		if C.EC_POINT_mul(p.c.g, p.p, s.bignum.bn, nil, nil,
@@ -264,7 +264,7 @@ func (c *curve) SecretLen() int {
 	return c.nlen
 }
 
-func (c *curve) Secret() abstract.Secret {
+func (c *curve) Secret() *abstract.Secret {
 	s := newSecret(c)
 	s.c = c
 	return s
@@ -274,7 +274,7 @@ func (c *curve) PointLen() int {
 	return 1 + c.plen // compressed encoding
 }
 
-func (c *curve) Point() abstract.Point {
+func (c *curve) Point() *abstract.Point {
 	return newPoint(c)
 }
 

--- a/openssl/secret.go
+++ b/openssl/secret.go
@@ -31,11 +31,11 @@ func newSecret(c *curve) *secret {
 
 func (s *secret) String() string { return s.BigInt().String() }
 
-func (s *secret) Equal(s2 abstract.Secret) bool {
+func (s *secret) Equal(s2 *abstract.Secret) bool {
 	return s.Cmp(&s2.(*secret).bignum) == 0
 }
 
-func (s *secret) Set(x abstract.Secret) abstract.Secret {
+func (s *secret) Set(x *abstract.Secret) *abstract.Secret {
 	xs := x.(*secret)
 	if C.BN_copy(s.bignum.bn, xs.bignum.bn) == nil {
 		panic("BN_copy: " + getErrString())
@@ -43,21 +43,21 @@ func (s *secret) Set(x abstract.Secret) abstract.Secret {
 	return s
 }
 
-func (s *secret) Zero() abstract.Secret {
+func (s *secret) Zero() *abstract.Secret {
 	if C.bn_zero(s.bignum.bn) == 0 {
 		panic("BN_zero: " + getErrString())
 	}
 	return s
 }
 
-func (s *secret) One() abstract.Secret {
+func (s *secret) One() *abstract.Secret {
 	if C.bn_one(s.bignum.bn) == 0 {
 		panic("BN_one: " + getErrString())
 	}
 	return s
 }
 
-func (s *secret) SetInt64(v int64) abstract.Secret {
+func (s *secret) SetInt64(v int64) *abstract.Secret {
 	neg := false
 	if v < 0 {
 		neg = true
@@ -83,7 +83,7 @@ func (s *secret) SetInt64(v int64) abstract.Secret {
 	return s
 }
 
-func (s *secret) Add(x, y abstract.Secret) abstract.Secret {
+func (s *secret) Add(x, y *abstract.Secret) *abstract.Secret {
 	xs := x.(*secret)
 	ys := y.(*secret)
 	if C.BN_mod_add(s.bignum.bn, xs.bignum.bn, ys.bignum.bn, s.c.n.bn,
@@ -93,7 +93,7 @@ func (s *secret) Add(x, y abstract.Secret) abstract.Secret {
 	return s
 }
 
-func (s *secret) Sub(x, y abstract.Secret) abstract.Secret {
+func (s *secret) Sub(x, y *abstract.Secret) *abstract.Secret {
 	xs := x.(*secret)
 	ys := y.(*secret)
 	if C.BN_mod_sub(s.bignum.bn, xs.bignum.bn, ys.bignum.bn, s.c.n.bn,
@@ -103,7 +103,7 @@ func (s *secret) Sub(x, y abstract.Secret) abstract.Secret {
 	return s
 }
 
-func (s *secret) Neg(x abstract.Secret) abstract.Secret {
+func (s *secret) Neg(x *abstract.Secret) *abstract.Secret {
 	xs := x.(*secret)
 	if C.BN_mod_sub(s.bignum.bn, s.c.n.bn, xs.bignum.bn, s.c.n.bn,
 		s.c.ctx) == 0 {
@@ -112,7 +112,7 @@ func (s *secret) Neg(x abstract.Secret) abstract.Secret {
 	return s
 }
 
-func (s *secret) Mul(x, y abstract.Secret) abstract.Secret {
+func (s *secret) Mul(x, y *abstract.Secret) *abstract.Secret {
 	xs := x.(*secret)
 	ys := y.(*secret)
 	if C.BN_mod_mul(s.bignum.bn, xs.bignum.bn, ys.bignum.bn, s.c.n.bn,
@@ -122,7 +122,7 @@ func (s *secret) Mul(x, y abstract.Secret) abstract.Secret {
 	return s
 }
 
-func (s *secret) Div(x, y abstract.Secret) abstract.Secret {
+func (s *secret) Div(x, y *abstract.Secret) *abstract.Secret {
 	xs := x.(*secret)
 	ys := y.(*secret)
 
@@ -143,7 +143,7 @@ func (s *secret) Div(x, y abstract.Secret) abstract.Secret {
 	return s
 }
 
-func (s *secret) Inv(x abstract.Secret) abstract.Secret {
+func (s *secret) Inv(x *abstract.Secret) *abstract.Secret {
 	xs := x.(*secret)
 	if C.BN_mod_inverse(s.bignum.bn, xs.bignum.bn, s.c.n.bn,
 		s.c.ctx) == nil {
@@ -152,7 +152,7 @@ func (s *secret) Inv(x abstract.Secret) abstract.Secret {
 	return s
 }
 
-func (s *secret) Pick(rand cipher.Stream) abstract.Secret {
+func (s *secret) Pick(rand cipher.Stream) *abstract.Secret {
 	s.bignum.RandMod(s.c.n, rand)
 	return s
 }

--- a/pbc/intpoint.go
+++ b/pbc/intpoint.go
@@ -47,16 +47,16 @@ func (p *intPoint) String() string {
 	return string(b[:l])
 }
 
-func (p *intPoint) Equal(p2 abstract.Point) bool {
+func (p *intPoint) Equal(p2 *abstract.Point) bool {
 	return C.element_cmp(&p.e[0], &p2.(*intPoint).e[0]) == 0
 }
 
-func (p *intPoint) Null() abstract.Point {
+func (p *intPoint) Null() *abstract.Point {
 	C.element_set1(&p.e[0])
 	return p
 }
 
-func (p *intPoint) Base() abstract.Point {
+func (p *intPoint) Base() *abstract.Point {
 	panic("XXX")
 }
 
@@ -64,7 +64,7 @@ func (p *intPoint) PickLen() int {
 	panic("XXX")
 }
 
-func (p *intPoint) Pick(data []byte, rand cipher.Stream) (abstract.Point, []byte) {
+func (p *intPoint) Pick(data []byte, rand cipher.Stream) (*abstract.Point, []byte) {
 	panic("XXX")
 }
 
@@ -72,22 +72,22 @@ func (p *intPoint) Data() ([]byte, error) {
 	panic("XXX")
 }
 
-func (p *intPoint) Add(a, b abstract.Point) abstract.Point {
+func (p *intPoint) Add(a, b *abstract.Point) *abstract.Point {
 	C.element_mul(&p.e[0], &a.(*intPoint).e[0], &b.(*intPoint).e[0])
 	return p
 }
 
-func (p *intPoint) Sub(a, b abstract.Point) abstract.Point {
+func (p *intPoint) Sub(a, b *abstract.Point) *abstract.Point {
 	C.element_div(&p.e[0], &a.(*intPoint).e[0], &b.(*intPoint).e[0])
 	return p
 }
 
-func (p *intPoint) Neg(a abstract.Point) abstract.Point {
+func (p *intPoint) Neg(a *abstract.Point) *abstract.Point {
 	C.element_invert(&p.e[0], &a.(*intPoint).e[0])
 	return p
 }
 
-func (p *intPoint) Mul(b abstract.Point, s abstract.Secret) abstract.Point {
+func (p *intPoint) Mul(b *abstract.Point, s *abstract.Secret) *abstract.Point {
 	if b == nil {
 		return p.Base().Mul(p, s)
 	}
@@ -96,7 +96,7 @@ func (p *intPoint) Mul(b abstract.Point, s abstract.Secret) abstract.Point {
 }
 
 // Pairing operation, satisfying PairingPoint interface for GT group.
-func (p *intPoint) Pairing(p1, p2 abstract.Point) abstract.Point {
+func (p *intPoint) Pairing(p1, p2 *abstract.Point) *abstract.Point {
 	C.element_pairing(&p.e[0], &p1.(*point).e[0], &p2.(*point).e[0])
 	return p
 }

--- a/pbc/pairing.go
+++ b/pbc/pairing.go
@@ -46,11 +46,11 @@ type PairingGroup interface {
 // Point interface extension for a point in a pairing target group (GT),
 // which supports the Pairing operation.
 type PairingPoint interface {
-	abstract.Point			// Standard Point operations
+	*abstract.Point			// Standard Point operations
 
 	// Compute the pairing of two points p1 and p2,
 	// which must be in the associated groups G1 and G2 respectively.
-	Pairing(p1,p2 abstract.Point) abstract.Point
+	Pairing(p1,p2 *abstract.Point) *abstract.Point
 }
 
 
@@ -166,7 +166,7 @@ func (g *g1group) SecretLen() int {
 	return int(C.pairing_length_in_bytes_Zr(&g.p.p[0]))
 }
 
-func (g *g1group) Secret() abstract.Secret {
+func (g *g1group) Secret() *abstract.Secret {
 	s := newSecret()
 	C.element_init_Zr(&s.e[0], &g.p.p[0])
 	return s
@@ -176,7 +176,7 @@ func (g *g1group) PointLen() int {
 	return int(C.pairing_length_in_bytes_compressed_G1(&g.p.p[0]))
 }
 
-func (g *g1group) Point() abstract.Point {
+func (g *g1group) Point() *abstract.Point {
 	p := newCurvePoint()
 	C.element_init_G1(&p.e[0], &g.p.p[0])
 	return p
@@ -197,7 +197,7 @@ func (g *g2group) SecretLen() int {
 	return int(C.pairing_length_in_bytes_Zr(&g.p.p[0]))
 }
 
-func (g *g2group) Secret() abstract.Secret {
+func (g *g2group) Secret() *abstract.Secret {
 	s := newSecret()
 	C.element_init_Zr(&s.e[0], &g.p.p[0])
 	return s
@@ -207,7 +207,7 @@ func (g *g2group) PointLen() int {
 	return int(C.pairing_length_in_bytes_compressed_G2(&g.p.p[0]))
 }
 
-func (g *g2group) Point() abstract.Point {
+func (g *g2group) Point() *abstract.Point {
 	p := newCurvePoint()
 	C.element_init_G2(&p.e[0], &g.p.p[0])
 	return p
@@ -228,7 +228,7 @@ func (g *gtgroup) SecretLen() int {
 	return int(C.pairing_length_in_bytes_Zr(&g.p.p[0]))
 }
 
-func (g *gtgroup) Secret() abstract.Secret {
+func (g *gtgroup) Secret() *abstract.Secret {
 	s := newSecret()
 	C.element_init_Zr(&s.e[0], &g.p.p[0])
 	return s
@@ -238,7 +238,7 @@ func (g *gtgroup) PointLen() int {
 	return int(C.pairing_length_in_bytes_GT(&g.p.p[0]))
 }
 
-func (g *gtgroup) Point() abstract.Point {
+func (g *gtgroup) Point() *abstract.Point {
 	return g.PairingPoint()
 }
 

--- a/pbc/point.go
+++ b/pbc/point.go
@@ -40,16 +40,16 @@ func (p *point) String() string {
 	return string(b[:l])
 }
 
-func (p *point) Equal(p2 abstract.Point) bool {
+func (p *point) Equal(p2 *abstract.Point) bool {
 	return C.element_cmp(&p.e[0], &p2.(*point).e[0]) == 0
 }
 
-func (p *point) Null() abstract.Point {
+func (p *point) Null() *abstract.Point {
 	C.element_set1(&p.e[0])
 	return p
 }
 
-func (p *point) Base() abstract.Point {
+func (p *point) Base() *abstract.Point {
 	panic("XXX")
 }
 
@@ -57,7 +57,7 @@ func (p *point) PickLen() int {
 	panic("XXX")
 }
 
-func (p *point) Pick(data []byte, rand cipher.Stream) (abstract.Point, []byte) {
+func (p *point) Pick(data []byte, rand cipher.Stream) (*abstract.Point, []byte) {
 	panic("XXX")
 }
 
@@ -65,22 +65,22 @@ func (p *point) Data() ([]byte, error) {
 	panic("XXX")
 }
 
-func (p *point) Add(a, b abstract.Point) abstract.Point {
+func (p *point) Add(a, b *abstract.Point) *abstract.Point {
 	C.element_mul(&p.e[0], &a.(*point).e[0], &b.(*point).e[0])
 	return p
 }
 
-func (p *point) Sub(a, b abstract.Point) abstract.Point {
+func (p *point) Sub(a, b *abstract.Point) *abstract.Point {
 	C.element_div(&p.e[0], &a.(*point).e[0], &b.(*point).e[0])
 	return p
 }
 
-func (p *point) Neg(a abstract.Point) abstract.Point {
+func (p *point) Neg(a *abstract.Point) *abstract.Point {
 	C.element_invert(&p.e[0], &a.(*point).e[0])
 	return p
 }
 
-func (p *point) Mul(b abstract.Point, s abstract.Secret) abstract.Point {
+func (p *point) Mul(b *abstract.Point, s *abstract.Secret) *abstract.Point {
 	if b == nil {
 		return p.Base().Mul(p, s)
 	}

--- a/pbc/secret.go
+++ b/pbc/secret.go
@@ -41,26 +41,26 @@ func (s *secret) String() string {
 	return string(b[:l])
 }
 
-func (s *secret) Equal(s2 abstract.Secret) bool {
+func (s *secret) Equal(s2 *abstract.Secret) bool {
 	return C.element_cmp(&s.e[0], &s2.(*secret).e[0]) == 0
 }
 
-func (s *secret) Set(x abstract.Secret) abstract.Secret {
+func (s *secret) Set(x *abstract.Secret) *abstract.Secret {
 	C.element_set(&s.e[0], &x.(*secret).e[0])
 	return s
 }
 
-func (s *secret) Zero() abstract.Secret {
+func (s *secret) Zero() *abstract.Secret {
 	C.element_set0(&s.e[0])
 	return s
 }
 
-func (s *secret) One() abstract.Secret {
+func (s *secret) One() *abstract.Secret {
 	C.element_set0(&s.e[0])
 	return s
 }
 
-func (s *secret) SetInt64(v int64) abstract.Secret {
+func (s *secret) SetInt64(v int64) *abstract.Secret {
 	vl := C.long(v)
 	if int64(vl) != v {
 		panic("Oops, int64 initializer doesn't fit into C.ulong")
@@ -73,36 +73,36 @@ func (s *secret) SetInt64(v int64) abstract.Secret {
 	return s
 }
 
-func (s *secret) Pick(rand cipher.Stream) abstract.Secret {
+func (s *secret) Pick(rand cipher.Stream) *abstract.Secret {
 	panic("XXX")
 }
 
-func (s *secret) Add(a, b abstract.Secret) abstract.Secret {
+func (s *secret) Add(a, b *abstract.Secret) *abstract.Secret {
 	C.element_add(&s.e[0], &a.(*secret).e[0], &b.(*secret).e[0])
 	return s
 }
 
-func (s *secret) Sub(a, b abstract.Secret) abstract.Secret {
+func (s *secret) Sub(a, b *abstract.Secret) *abstract.Secret {
 	C.element_sub(&s.e[0], &a.(*secret).e[0], &b.(*secret).e[0])
 	return s
 }
 
-func (s *secret) Neg(a abstract.Secret) abstract.Secret {
+func (s *secret) Neg(a *abstract.Secret) *abstract.Secret {
 	C.element_neg(&s.e[0], &a.(*secret).e[0])
 	return s
 }
 
-func (s *secret) Mul(a, b abstract.Secret) abstract.Secret {
+func (s *secret) Mul(a, b *abstract.Secret) *abstract.Secret {
 	C.element_mul(&s.e[0], &a.(*secret).e[0], &b.(*secret).e[0])
 	return s
 }
 
-func (s *secret) Div(a, b abstract.Secret) abstract.Secret {
+func (s *secret) Div(a, b *abstract.Secret) *abstract.Secret {
 	C.element_div(&s.e[0], &a.(*secret).e[0], &b.(*secret).e[0])
 	return s
 }
 
-func (s *secret) Inv(a abstract.Secret) abstract.Secret {
+func (s *secret) Inv(a *abstract.Secret) *abstract.Secret {
 	C.element_invert(&s.e[0], &a.(*secret).e[0])
 	return s
 }

--- a/poly/deal_test.go
+++ b/poly/deal_test.go
@@ -49,8 +49,8 @@ func produceinsurerKeys() []*config.KeyPair {
 	return newArray
 }
 
-func produceinsurerList() []abstract.Point {
-	newArray := make([]abstract.Point, numInsurers, numInsurers)
+func produceinsurerList() []*abstract.Point {
+	newArray := make([]*abstract.Point, numInsurers, numInsurers)
 	for i := 0; i < numInsurers; i++ {
 		newArray[i] = insurerKeys[i].Public
 	}
@@ -448,7 +448,7 @@ func TestDealConstructDeal(t *testing.T) {
 	test := func() {
 		defer recoverTest(t, "Constructdealshould have panicked.")
 		new(Deal).ConstructDeal(secretKey, DealerKey, 2, r,
-			[]abstract.Point{DealerKey.Public})
+			[]*abstract.Point{DealerKey.Public})
 	}
 	test()
 
@@ -524,14 +524,14 @@ func TestDealverifyDeal(t *testing.T) {
 
 	deal = new(Deal).ConstructDeal(secretKey, DealerKey, pt,
 		r, insurerList)
-	deal.insurers = []abstract.Point{}
+	deal.insurers = []*abstract.Point{}
 	if deal.verifyDeal() == nil {
 		t.Error("dealis invalid: insurers list is the wrong length")
 	}
 
 	deal = new(Deal).ConstructDeal(secretKey, DealerKey, pt,
 		r, insurerList)
-	deal.secrets = []abstract.Secret{}
+	deal.secrets = []*abstract.Secret{}
 	if deal.verifyDeal() == nil {
 		t.Error("dealis invalid: secrets list is the wrong length")
 	}
@@ -855,7 +855,7 @@ func TestDealEqual(t *testing.T) {
 		r, insurerList)
 	deal.secrets = basicDeal.secrets
 	deal.pubPoly = basicDeal.pubPoly
-	deal.insurers = make([]abstract.Point, deal.n, deal.n)
+	deal.insurers = make([]*abstract.Point, deal.n, deal.n)
 	copy(deal.insurers, insurerList)
 	deal.insurers[numInsurers-1] = suite.Point().Base()
 	if basicDeal.Equal(deal) {

--- a/poly/helper_test.go
+++ b/poly/helper_test.go
@@ -27,8 +27,8 @@ func generateKeyPairList(n int) []*config.KeyPair {
 	return l
 }
 
-func generatePublicListFromPrivate(private []*config.KeyPair) []abstract.Point {
-	l := make([]abstract.Point, len(private))
+func generatePublicListFromPrivate(private []*config.KeyPair) []*abstract.Point {
+	l := make([]*abstract.Point, len(private))
 	for i := 0; i < len(private); i++ {
 		l[i] = private[i].Public
 	}

--- a/poly/joint.go
+++ b/poly/joint.go
@@ -35,7 +35,7 @@ type SharedSecret struct {
 	Pub *PubPoly
 
 	// The share of the shared secret
-	Share *abstract.Secret
+	Share **abstract.Secret
 
 	// The index where the share has been evaluated in the shared private polynomial
 	// and the index to use where the share can be checked against the shared

--- a/poly/schnorr.go
+++ b/poly/schnorr.go
@@ -43,7 +43,7 @@ type Schnorr struct {
 	// For each round, we have the following members :
 
 	// hash is the hash of the message
-	hash *abstract.Secret
+	hash **abstract.Secret
 
 	// The short term shared secret, only to be used for this signature,
 	// i.e. the random secret in the regular schnorr signature
@@ -63,7 +63,7 @@ type SchnorrPartialSig struct {
 	Index int
 
 	// The partial signature itself
-	Part *abstract.Secret
+	Part **abstract.Secret
 }
 
 // SchnorrSig represents the final signature of a distribtued threshold schnorr signature
@@ -74,7 +74,7 @@ type SchnorrPartialSig struct {
 type SchnorrSig struct {
 
 	// the signature itself
-	Signature *abstract.Secret
+	Signature **abstract.Secret
 
 	// the random public polynomial used during the signature generation
 	Random *PubPoly
@@ -113,7 +113,7 @@ func (s *Schnorr) NewRound(random *SharedSecret, h hash.Hash) error {
 // Returns a hash of the message and the random secret:
 // H( m || V )
 // Returns an error if something went wrong with the marshalling
-func (s *Schnorr) hashMessage(msg []byte, v abstract.Point) (abstract.Secret, error) {
+func (s *Schnorr) hashMessage(msg []byte, v *abstract.Point) (*abstract.Secret, error) {
 	vb, err := v.MarshalBinary()
 	if err != nil {
 		return nil, err

--- a/poly/sharing.go
+++ b/poly/sharing.go
@@ -26,7 +26,7 @@ import (
 
 // Private polynomial for Shamir secret sharing.
 type PriPoly struct {
-	g abstract.Group    // Cryptographic group in use
+	g abstract.Group     // Cryptographic group in use
 	s []*abstract.Secret // Coefficients of secret polynomial
 }
 
@@ -112,8 +112,8 @@ func (p *PriPoly) String() string {
 
 // Secret shares generated from a private polynomial.
 type PriShares struct {
-	g abstract.Group    // Cryptographic group in use
-	k int               // Reconstruction threshold
+	g abstract.Group     // Cryptographic group in use
+	k int                // Reconstruction threshold
 	s []*abstract.Secret // Secret shares, one per sharing party.
 }
 
@@ -219,7 +219,7 @@ func (ps *PriShares) String() string {
 
 // A public commitment to a secret-sharing polynomial.
 type PubPoly struct {
-	g abstract.Group   // Cryptographic group in use
+	g abstract.Group    // Cryptographic group in use
 	b *abstract.Point   // Base point, nil for standard base
 	p []*abstract.Point // Commitments to polynomial coefficients
 }
@@ -392,8 +392,8 @@ func (p *PubPoly) String() string {
 
 // Public commitments to shares generated from a private polynomial.
 type PubShares struct {
-	g abstract.Group   // Cryptographic group in use
-	k int              // Reconstruction threshold
+	g abstract.Group    // Cryptographic group in use
+	k int               // Reconstruction threshold
 	b *abstract.Point   // Base point, nil for standard base
 	p []*abstract.Point // Commitment shares, one per sharing party.
 }

--- a/poly/sharing_test.go
+++ b/poly/sharing_test.go
@@ -44,18 +44,18 @@ func deferTest(t *testing.T, message string) {
 	}
 }
 
-func producePriPoly(g abstract.Group, k int, s abstract.Secret) *PriPoly {
+func producePriPoly(g abstract.Group, k int, s *abstract.Secret) *PriPoly {
 	return new(PriPoly).Pick(g, k, s, random.Stream)
 }
 
-func producePriShares(g abstract.Group, k, n int, s abstract.Secret) *PriShares {
+func producePriShares(g abstract.Group, k, n int, s *abstract.Secret) *PriShares {
 
 	testPoly := producePriPoly(g, k, s)
 	return new(PriShares).Split(testPoly, n)
 }
 
-func producePubPoly(g abstract.Group, k, n int, s abstract.Secret,
-	p abstract.Point) *PubPoly {
+func producePubPoly(g abstract.Group, k, n int, s *abstract.Secret,
+	p *abstract.Point) *PubPoly {
 
 	testPriPoly := producePriPoly(g, k, s)
 	testPubPoly := new(PubPoly)
@@ -63,8 +63,8 @@ func producePubPoly(g abstract.Group, k, n int, s abstract.Secret,
 	return testPubPoly.Commit(testPriPoly, p)
 }
 
-func producePubShares(g abstract.Group, k, n, t int, s abstract.Secret,
-	p abstract.Point) *PubShares {
+func producePubShares(g abstract.Group, k, n, t int, s *abstract.Secret,
+	p *abstract.Point) *PubShares {
 
 	testPubPoly := producePubPoly(g, k, n, s, p)
 	return new(PubShares).Split(testPubPoly, t)

--- a/proof/context.go
+++ b/proof/context.go
@@ -1,6 +1,5 @@
 package proof
 
-
 // Prover represents the prover role in an arbitrary Sigma-protocol.
 // A prover is simply a higher-order function that takes a ProverContext,
 // runs the protocol while making calls to the ProverContext methods as needed,
@@ -15,8 +14,6 @@ type Prover func(ctx ProverContext) error
 // runs the protocol while making calls to VerifierContext methods as needed,
 // and returns nil on success or an error once the protocol run concludes.
 type Verifier func(ctx VerifierContext) error
-
-
 
 // ProverContext represents the abstract environment
 // required by the prover in a Sigma protocol.
@@ -37,9 +34,9 @@ type Verifier func(ctx VerifierContext) error
 // in this case the prover simply calls PubRand() multiple times.
 //
 type ProverContext interface {
-	Put(message interface{}) error 		// Send message to verifier
-	PubRand(message...interface{}) error	// Get public randomness
-	PriRand(message...interface{})		// Get private randomness
+	Put(message interface{}) error        // Send message to verifier
+	PubRand(message ...interface{}) error // Get public randomness
+	PriRand(message ...interface{})       // Get private randomness
 }
 
 // ProverContext represents the abstract environment
@@ -54,7 +51,6 @@ type ProverContext interface {
 // in both non-interactive proofs (e.g., via HashProve)
 // and in interactive proofs (e.g., via DeniableProver).
 type VerifierContext interface {
-	Get(message interface{}) error		// Receive message from prover
-	PubRand(message...interface{}) error	// Get public randomness
+	Get(message interface{}) error        // Receive message from prover
+	PubRand(message ...interface{}) error // Get public randomness
 }
-

--- a/proof/deniable_test.go
+++ b/proof/deniable_test.go
@@ -16,8 +16,8 @@ type node struct {
 	i    int
 	done bool
 
-	x abstract.Secret
-	X abstract.Point
+	x *abstract.Secret
+	X *abstract.Point
 
 	proto  clique.Protocol
 	outbox chan []byte
@@ -100,14 +100,14 @@ func TestDeniable(t *testing.T) {
 	for i := 0; i < nnodes; i++ {
 		n := nodes[i]
 		pred := Rep("X", "x", "B")
-		sval := map[string]abstract.Secret{"x": n.x}
-		pval := map[string]abstract.Point{"B": B, "X": n.X}
+		sval := map[string]*abstract.Secret{"x": n.x}
+		pval := map[string]*abstract.Point{"B": B, "X": n.X}
 		prover := pred.Prover(suite, sval, pval, nil)
 
 		vi := (i + 2) % nnodes // which node's proof to verify
 		vrfs := make([]Verifier, nnodes)
 		vpred := Rep("X", "x", "B")
-		vpval := map[string]abstract.Point{"B": B, "X": nodes[vi].X}
+		vpval := map[string]*abstract.Point{"B": B, "X": nodes[vi].X}
 		vrfs[vi] = vpred.Verifier(suite, vpval)
 
 		n.proto = DeniableProver(suite, i, prover, vrfs)

--- a/proof/hash_test.go
+++ b/proof/hash_test.go
@@ -23,8 +23,8 @@ func ExampleHashProve_1() {
 	// Generate a proof that we know the discrete logarithm of X.
 	M := "Hello World!" // message we want to sign
 	rep := Rep("X", "x", "B")
-	sec := map[string]abstract.Secret{"x": x}
-	pub := map[string]abstract.Point{"B": B, "X": X}
+	sec := map[string]*abstract.Secret{"x": x}
+	pub := map[string]*abstract.Point{"B": B, "X": X}
 	prover := rep.Prover(suite, sec, pub, nil)
 	proof, _ := HashProve(suite, M, rand, prover)
 	fmt.Print("Signature:\n" + hex.Dump(proof))
@@ -84,7 +84,7 @@ func ExampleHashProve_2() {
 	B := suite.Point().Base() // standard base point
 
 	// Create an anonymity ring of random "public keys"
-	X := make([]abstract.Point, 3)
+	X := make([]*abstract.Point, 3)
 	for i := range X { // pick random points
 		X[i], _ = suite.Point().Pick(nil, rand)
 	}
@@ -102,8 +102,8 @@ func ExampleHashProve_2() {
 	linkTag := suite.Point().Mul(linkBase, x)
 
 	// Generate the proof predicate: an OR branch for each public key.
-	sec := map[string]abstract.Secret{"x": x}
-	pub := map[string]abstract.Point{"B": B, "BT": linkBase, "T": linkTag}
+	sec := map[string]*abstract.Secret{"x": x}
+	pub := map[string]*abstract.Point{"B": B, "BT": linkBase, "T": linkTag}
 	preds := make([]Predicate, len(X))
 	for i := range X {
 		name := fmt.Sprintf("X[%d]", i) // "X[0]","X[1]",...

--- a/proof/proof.go
+++ b/proof/proof.go
@@ -10,10 +10,8 @@ import (
 	"github.com/dedis/crypto/abstract"
 )
 
-
 // XXX simplify using the reflection API?
 // just pass a 'struct' with the Point and Secret variables?
-
 
 /*
 A Predicate is a composable logic expression in a knowledge proof system,
@@ -55,7 +53,7 @@ For now we simply require expressions to be in the appropriate form.
 type Predicate interface {
 
 	// Create a Prover proving the statement this Predicate represents.
-	Prover(suite abstract.Suite, secrets map[string]*abstract.Secret, 
+	Prover(suite abstract.Suite, secrets map[string]*abstract.Secret,
 		points map[string]*abstract.Point, choice map[Predicate]int) Prover
 
 	// Create a Verifier for the statement this Predicate represents.
@@ -84,7 +82,6 @@ type Predicate interface {
 	verify(prf *proof, c *abstract.Secret, r []*abstract.Secret) error
 }
 
-
 // stringification precedence levels
 const (
 	precNone = iota
@@ -93,53 +90,48 @@ const (
 	precAtom
 )
 
-
-
-
 // Internal prover/verifier state
 type proof struct {
 	s abstract.Suite
 
-	nsvars int			// number of Secret variables
-	npvars int			// number of Point variables
-	svar, pvar []string		// Secret and Point variable names
-	sidx, pidx map[string]int	// Maps from strings to variable indexes
+	nsvars     int            // number of Secret variables
+	npvars     int            // number of Point variables
+	svar, pvar []string       // Secret and Point variable names
+	sidx, pidx map[string]int // Maps from strings to variable indexes
 
-	pval map[string]*abstract.Point	// values of public Point variables
+	pval map[string]*abstract.Point // values of public Point variables
 
 	// prover-specific state
-	pc ProverContext
-	sval map[string]*abstract.Secret	// values of private Secret variables
-	choice map[Predicate]int	// OR branch choices set by caller
-	pp map[Predicate]*proverPred	// per-predicate prover state
+	pc     ProverContext
+	sval   map[string]*abstract.Secret // values of private Secret variables
+	choice map[Predicate]int           // OR branch choices set by caller
+	pp     map[Predicate]*proverPred   // per-predicate prover state
 
 	// verifier-specific state
 	vc VerifierContext
-	vp map[Predicate]*verifierPred	// per-predicate verifier state
+	vp map[Predicate]*verifierPred // per-predicate verifier state
 }
 type proverPred struct {
-	w *abstract.Secret		// secret pre-challenge
-	v []*abstract.Secret	// secret blinding factor for each variable
-	wi []*abstract.Secret	// OR predicates: individual sub-challenges
+	w  *abstract.Secret   // secret pre-challenge
+	v  []*abstract.Secret // secret blinding factor for each variable
+	wi []*abstract.Secret // OR predicates: individual sub-challenges
 }
 type verifierPred struct {
-	V *abstract.Point		// public commitment produced by verifier
-	r []*abstract.Secret	// per-variable responses produced by verifier
+	V *abstract.Point    // public commitment produced by verifier
+	r []*abstract.Secret // per-variable responses produced by verifier
 }
-
-
 
 ////////// Rep predicate //////////
 
 // A term describes a point-multiplication term in a representation expression.
 type term struct {
-	S string	// Secret multiplier for this term
-	B string	// Generator for this term
+	S string // Secret multiplier for this term
+	B string // Generator for this term
 }
 
 type repPred struct {
-	P string	// Public point of which a representation is known
-	T []term	// Terms comprising the known representation
+	P string // Public point of which a representation is known
+	T []term // Terms comprising the known representation
 }
 
 // Rep creates a predicate stating that the prover knows
@@ -158,15 +150,15 @@ type repPred struct {
 // such that point P is the sum x1*B1+...+xn*Bn.
 //
 func Rep(P string, SB ...string) Predicate {
-	if len(SB) & 1 != 0 {
+	if len(SB)&1 != 0 {
 		panic("mismatched Secret")
 	}
-	t := make([]term,len(SB)/2)
-	for i := range(t) {
+	t := make([]term, len(SB)/2)
+	for i := range t {
 		t[i].S = SB[i*2]
 		t[i].B = SB[i*2+1]
 	}
-	return &repPred{P,t}
+	return &repPred{P, t}
 }
 
 // Return a string representation of this proof-of-representation predicate,
@@ -177,7 +169,7 @@ func (rp *repPred) String() string {
 
 func (rp *repPred) precString(prec int) string {
 	s := rp.P + "="
-	for i := range(rp.T) {
+	for i := range rp.T {
 		if i > 0 {
 			s += "+"
 		}
@@ -191,7 +183,7 @@ func (rp *repPred) precString(prec int) string {
 
 func (rp *repPred) enumVars(prf *proof) {
 	prf.enumPointVar(rp.P)
-	for i := range(rp.T) {
+	for i := range rp.T {
 		prf.enumSecretVar(rp.T[i].S)
 		prf.enumPointVar(rp.T[i].B)
 	}
@@ -201,19 +193,19 @@ func (rp *repPred) commit(prf *proof, w *abstract.Secret, pv []*abstract.Secret)
 
 	// Create per-predicate prover state
 	v := prf.makeSecrets(pv)
-	pp := &proverPred{w,v,nil}
+	pp := &proverPred{w, v, nil}
 	prf.pp[rp] = pp
 
 	// Compute commit V=wY+v1G1+...+vkGk
 	V := prf.s.Point()
-	if w != nil {	// We're on a non-obligated branch
-		V.Mul(prf.pval[rp.P],w)
-	} else {	// We're on a proof-obligated branch, so w=0
+	if w != nil { // We're on a non-obligated branch
+		V.Mul(prf.pval[rp.P], w)
+	} else { // We're on a proof-obligated branch, so w=0
 		V.Null()
 	}
 	P := prf.s.Point()
 	for i := 0; i < len(rp.T); i++ {
-		t := rp.T[i]	// current term
+		t := rp.T[i] // current term
 		s := prf.sidx[t.S]
 
 		// Choose a blinding secret the first time
@@ -222,8 +214,8 @@ func (rp *repPred) commit(prf *proof, w *abstract.Secret, pv []*abstract.Secret)
 			v[s] = prf.s.Secret()
 			prf.pc.PriRand(v[s])
 		}
-		P.Mul(prf.pval[t.B],v[s])
-		V.Add(V,P)
+		P.Mul(prf.pval[t.B], v[s])
+		V.Add(V, P)
 	}
 
 	// Encode and send the commitment to the verifier
@@ -231,14 +223,14 @@ func (rp *repPred) commit(prf *proof, w *abstract.Secret, pv []*abstract.Secret)
 }
 
 func (rp *repPred) respond(prf *proof, c *abstract.Secret,
-			pr []*abstract.Secret) error {
+	pr []*abstract.Secret) error {
 	pp := prf.pp[rp]
 
 	// Create a response array for this OR-domain if not done already
 	r := prf.makeSecrets(pr)
 
-	for i := range(rp.T) {
-		t := rp.T[i]	// current term
+	for i := range rp.T {
+		t := rp.T[i] // current term
 		s := prf.sidx[t.S]
 
 		// Produce a correct response for each variable
@@ -255,8 +247,8 @@ func (rp *repPred) respond(prf *proof, c *abstract.Secret,
 			// so we need to calculate the correct response
 			// as r = v-cx where x is the secret variable
 			ri := prf.s.Secret()
-			ri.Mul(c,prf.sval[t.S])
-			ri.Sub(pp.v[s],ri)
+			ri.Mul(c, prf.sval[t.S])
+			ri.Sub(pp.v[s], ri)
 			r[s] = ri
 		}
 	}
@@ -270,7 +262,7 @@ func (rp *repPred) getCommits(prf *proof, pr []*abstract.Secret) error {
 	// Create per-predicate verifier state
 	V := prf.s.Point()
 	r := prf.makeSecrets(pr)
-	vp := &verifierPred{V,r}
+	vp := &verifierPred{V, r}
 	prf.vp[rp] = vp
 
 	// Get the commitment for this representation
@@ -279,8 +271,8 @@ func (rp *repPred) getCommits(prf *proof, pr []*abstract.Secret) error {
 	}
 
 	// Fill in the r vector with the responses we'll need.
-	for i := range(rp.T) {
-		t := rp.T[i]	// current term
+	for i := range rp.T {
+		t := rp.T[i] // current term
 		s := prf.sidx[t.S]
 		if r[s] == nil {
 			r[s] = prf.s.Secret()
@@ -294,19 +286,19 @@ func (rp *repPred) verify(prf *proof, c *abstract.Secret, pr []*abstract.Secret)
 	r := vp.r
 
 	// Get the needed responses if a parent didn't already
-	if e := prf.getResponses(pr,r); e != nil {
+	if e := prf.getResponses(pr, r); e != nil {
 		return e
 	}
 
 	// Recompute commit V=cY+r1G1+...+rkGk
 	V := prf.s.Point()
-	V.Mul(prf.pval[rp.P],c)
+	V.Mul(prf.pval[rp.P], c)
 	P := prf.s.Point()
 	for i := 0; i < len(rp.T); i++ {
-		t := rp.T[i]	// current term
+		t := rp.T[i] // current term
 		s := prf.sidx[t.S]
-		P.Mul(prf.pval[t.B],r[s])
-		V.Add(V,P)
+		P.Mul(prf.pval[t.B], r[s])
+		V.Add(V, P)
 	}
 	if !V.Equal(vp.V) {
 		return errors.New("invalid proof: commit mismatch")
@@ -315,18 +307,16 @@ func (rp *repPred) verify(prf *proof, c *abstract.Secret, pr []*abstract.Secret)
 	return nil
 }
 
-func (rp *repPred) Prover(suite abstract.Suite, secrets map[string]*abstract.Secret, 
-			points map[string]*abstract.Point,
-			choice map[Predicate]int) Prover {
-	return proof{}.init(suite,rp).prover(rp,secrets,points,choice)
+func (rp *repPred) Prover(suite abstract.Suite, secrets map[string]*abstract.Secret,
+	points map[string]*abstract.Point,
+	choice map[Predicate]int) Prover {
+	return proof{}.init(suite, rp).prover(rp, secrets, points, choice)
 }
 
 func (rp *repPred) Verifier(suite abstract.Suite,
-			points map[string]*abstract.Point) Verifier {
-	return proof{}.init(suite,rp).verifier(rp,points)
+	points map[string]*abstract.Point) Verifier {
+	return proof{}.init(suite, rp).verifier(rp, points)
 }
-
-
 
 ////////// And predicate //////////
 
@@ -334,7 +324,7 @@ type andPred []Predicate
 
 // An And predicate states that all of the constituent sub-predicates are true.
 // And predicates may contain Rep predicates and/or other And predicates.
-func And(sub...Predicate) Predicate {
+func And(sub ...Predicate) Predicate {
 	and := andPred(sub)
 	return &and
 }
@@ -358,7 +348,7 @@ func (ap *andPred) precString(prec int) string {
 
 func (ap *andPred) enumVars(prf *proof) {
 	sub := []Predicate(*ap)
-	for i := range(sub) {
+	for i := range sub {
 		sub[i].enumVars(prf)
 	}
 }
@@ -373,7 +363,7 @@ func (ap *andPred) commit(prf *proof, w *abstract.Secret, pv []*abstract.Secret)
 
 	// Recursively generate commitments
 	for i := 0; i < len(sub); i++ {
-		if e := sub[i].commit(prf,w,v); e != nil {
+		if e := sub[i].commit(prf, w, v); e != nil {
 			return e
 		}
 	}
@@ -387,8 +377,8 @@ func (ap *andPred) respond(prf *proof, c *abstract.Secret, pr []*abstract.Secret
 
 	// Recursively compute responses in all sub-predicates
 	r := prf.makeSecrets(pr)
-	for i := range(sub) {
-		if e := sub[i].respond(prf,c,r); e != nil {
+	for i := range sub {
+		if e := sub[i].respond(prf, c, r); e != nil {
 			return e
 		}
 	}
@@ -400,11 +390,11 @@ func (ap *andPred) getCommits(prf *proof, pr []*abstract.Secret) error {
 
 	// Create per-predicate verifier state
 	r := prf.makeSecrets(pr)
-	vp := &verifierPred{nil,r}
+	vp := &verifierPred{nil, r}
 	prf.vp[ap] = vp
 
-	for i := range(sub) {
-		if e := sub[i].getCommits(prf,r); e != nil {
+	for i := range sub {
+		if e := sub[i].getCommits(prf, r); e != nil {
 			return e
 		}
 	}
@@ -416,29 +406,27 @@ func (ap *andPred) verify(prf *proof, c *abstract.Secret, pr []*abstract.Secret)
 	vp := prf.vp[ap]
 	r := vp.r
 
-	if e := prf.getResponses(pr,r); e != nil {
+	if e := prf.getResponses(pr, r); e != nil {
 		return e
 	}
-	for i := range(sub) {
-		if e := sub[i].verify(prf,c,r); e != nil {
+	for i := range sub {
+		if e := sub[i].verify(prf, c, r); e != nil {
 			return e
 		}
 	}
 	return nil
 }
 
-func (ap *andPred) Prover(suite abstract.Suite, secrets map[string]*abstract.Secret, 
-			points map[string]*abstract.Point,
-			choice map[Predicate]int) Prover {
-	return proof{}.init(suite,ap).prover(ap,secrets,points,choice)
+func (ap *andPred) Prover(suite abstract.Suite, secrets map[string]*abstract.Secret,
+	points map[string]*abstract.Point,
+	choice map[Predicate]int) Prover {
+	return proof{}.init(suite, ap).prover(ap, secrets, points, choice)
 }
 
 func (ap *andPred) Verifier(suite abstract.Suite,
-			points map[string]*abstract.Point) Verifier {
-	return proof{}.init(suite,ap).verifier(ap,points)
+	points map[string]*abstract.Point) Verifier {
+	return proof{}.init(suite, ap).verifier(ap, points)
 }
-
-
 
 ////////// Or predicate //////////
 
@@ -448,7 +436,7 @@ type orPred []Predicate
 // at least one of the sub-predicates to be true,
 // but the proof does not reveal any information about which.
 
-func Or(sub...Predicate) Predicate {
+func Or(sub ...Predicate) Predicate {
 	or := orPred(sub)
 	return &or
 }
@@ -472,29 +460,29 @@ func (op *orPred) precString(prec int) string {
 
 func (op *orPred) enumVars(prf *proof) {
 	sub := []Predicate(*op)
-	for i := range(sub) {
+	for i := range sub {
 		sub[i].enumVars(prf)
 	}
 }
 
 func (op *orPred) commit(prf *proof, w *abstract.Secret, pv []*abstract.Secret) error {
 	sub := []Predicate(*op)
-	if pv != nil {		// only happens within an AND expression
+	if pv != nil { // only happens within an AND expression
 		panic("can't have OR predicates within AND predicates")
 	}
 
 	// Create per-predicate prover state
 	wi := make([]*abstract.Secret, len(sub))
-	pp := &proverPred{w,nil,wi}
+	pp := &proverPred{w, nil, wi}
 	prf.pp[op] = pp
 
 	// Choose pre-challenges for our subs.
 	if w == nil {
 		// We're on a proof-obligated branch;
 		// choose random pre-challenges for only non-obligated subs.
-		choice,ok := prf.choice[op]
+		choice, ok := prf.choice[op]
 		if !ok || choice < 0 || choice >= len(sub) {
-			panic("no choice of proof branch for OR-predicate "+
+			panic("no choice of proof branch for OR-predicate " +
 				op.String())
 		}
 		for i := 0; i < len(sub); i++ {
@@ -507,12 +495,12 @@ func (op *orPred) commit(prf *proof, w *abstract.Secret, pv []*abstract.Secret) 
 		// Since w != nil, we're in a non-obligated branch,
 		// so choose random pre-challenges for all subs
 		// such that they add up to the master pre-challenge w.
-		last := len(sub)-1		// index of last sub
+		last := len(sub) - 1 // index of last sub
 		wl := prf.s.Secret().Set(w)
-		for i := 0; i < last; i++ {	// choose all but last
+		for i := 0; i < last; i++ { // choose all but last
 			wi[i] = prf.s.Secret()
 			prf.pc.PriRand(wi[i])
-			wl.Sub(wl,wi[i])
+			wl.Sub(wl, wi[i])
 		}
 		wi[last] = wl
 	}
@@ -520,7 +508,7 @@ func (op *orPred) commit(prf *proof, w *abstract.Secret, pv []*abstract.Secret) 
 	// Now recursively choose commitments within each sub
 	for i := 0; i < len(sub); i++ {
 		// Fresh variable-blinding secrets for each pre-commitment
-		if e := sub[i].commit(prf,wi[i],nil); e != nil {
+		if e := sub[i].commit(prf, wi[i], nil); e != nil {
 			return e
 		}
 	}
@@ -542,7 +530,7 @@ func (op *orPred) respond(prf *proof, c *abstract.Secret, pr []*abstract.Secret)
 		choice := prf.choice[op]
 		for i := 0; i < len(sub); i++ {
 			if i != choice {
-				cs.Sub(cs,ci[i])
+				cs.Sub(cs, ci[i])
 			}
 		}
 		ci[choice] = cs
@@ -556,8 +544,8 @@ func (op *orPred) respond(prf *proof, c *abstract.Secret, pr []*abstract.Secret)
 	}
 
 	// Recursively compute responses in all subtrees
-	for i := range(sub) {
-		if e := sub[i].respond(prf,ci[i],nil); e != nil {
+	for i := range sub {
+		if e := sub[i].respond(prf, ci[i], nil); e != nil {
 			return e
 		}
 	}
@@ -568,8 +556,8 @@ func (op *orPred) respond(prf *proof, c *abstract.Secret, pr []*abstract.Secret)
 // Get from the verifier all the commitments needed for this predicate
 func (op *orPred) getCommits(prf *proof, pr []*abstract.Secret) error {
 	sub := []Predicate(*op)
-	for i := range(sub) {
-		if e := sub[i].getCommits(prf,nil); e != nil {
+	for i := range sub {
+		if e := sub[i].getCommits(prf, nil); e != nil {
 			return e
 		}
 	}
@@ -599,13 +587,13 @@ func (op *orPred) verify(prf *proof, c *abstract.Secret, pr []*abstract.Secret) 
 			return errors.New("invalid proof: bad sub-challenges")
 		}
 
-	} else {	// trivial single-sub OR
+	} else { // trivial single-sub OR
 		ci[0] = c
 	}
 
 	// Recursively verify all subs
-	for i := range(sub) {
-		if e := sub[i].verify(prf,ci[i], nil); e != nil {
+	for i := range sub {
+		if e := sub[i].verify(prf, ci[i], nil); e != nil {
 			return e
 		}
 	}
@@ -613,18 +601,16 @@ func (op *orPred) verify(prf *proof, c *abstract.Secret, pr []*abstract.Secret) 
 	return nil
 }
 
-func (op *orPred) Prover(suite abstract.Suite, secrets map[string]*abstract.Secret, 
-			points map[string]*abstract.Point,
-			choice map[Predicate]int) Prover {
-	return proof{}.init(suite,op).prover(op,secrets,points,choice)
+func (op *orPred) Prover(suite abstract.Suite, secrets map[string]*abstract.Secret,
+	points map[string]*abstract.Point,
+	choice map[Predicate]int) Prover {
+	return proof{}.init(suite, op).prover(op, secrets, points, choice)
 }
 
 func (op *orPred) Verifier(suite abstract.Suite,
-			points map[string]*abstract.Point) Verifier {
-	return proof{}.init(suite,op).verifier(op,points)
+	points map[string]*abstract.Point) Verifier {
+	return proof{}.init(suite, op).verifier(op, points)
 }
-
-
 
 /*
 type lin struct {
@@ -640,8 +626,6 @@ func (p *Prover) Linear(a1,a2,b *abstract.Secret, x1,x2 PriVar) {
 	return &lin{a1,a2,b,x1,x2}
 }
 */
-
-
 
 func (prf proof) init(suite abstract.Suite, pred Predicate) *proof {
 	prf.s = suite
@@ -684,7 +668,7 @@ func (prf *proof) makeSecrets(pr []*abstract.Secret) []*abstract.Secret {
 // Transmit our response-array if a corresponding makeSecrets() created it.
 func (prf *proof) sendResponses(pr []*abstract.Secret, r []*abstract.Secret) error {
 	if pr == nil {
-		for i := range(r) {
+		for i := range r {
 			// Send responses only for variables
 			// that were used in this OR-domain.
 			if r[i] != nil {
@@ -701,7 +685,7 @@ func (prf *proof) sendResponses(pr []*abstract.Secret, r []*abstract.Secret) err
 // if a corresponding makeSecrets() call created it.
 func (prf *proof) getResponses(pr []*abstract.Secret, r []*abstract.Secret) error {
 	if pr == nil {
-		for i := range(r) {
+		for i := range r {
 			if r[i] != nil {
 				if e := prf.vc.Get(r[i]); e != nil {
 					return e
@@ -712,9 +696,9 @@ func (prf *proof) getResponses(pr []*abstract.Secret, r []*abstract.Secret) erro
 	return nil
 }
 
-func (prf *proof) prove(p Predicate, sval map[string]*abstract.Secret, 
-			pval map[string]*abstract.Point,
-			choice map[Predicate]int, pc ProverContext) error {
+func (prf *proof) prove(p Predicate, sval map[string]*abstract.Secret,
+	pval map[string]*abstract.Point,
+	choice map[Predicate]int, pc ProverContext) error {
 	prf.pc = pc
 	prf.sval = sval
 	prf.pval = pval
@@ -722,7 +706,7 @@ func (prf *proof) prove(p Predicate, sval map[string]*abstract.Secret,
 	prf.pp = make(map[Predicate]*proverPred)
 
 	// Generate all commitments
-	if e := p.commit(prf,nil,nil); e != nil {
+	if e := p.commit(prf, nil, nil); e != nil {
 		return e
 	}
 
@@ -733,18 +717,18 @@ func (prf *proof) prove(p Predicate, sval map[string]*abstract.Secret,
 	}
 
 	// Generate all responses based on master challenge
-	return p.respond(prf,c,nil)
+	return p.respond(prf, c, nil)
 }
 
 func (prf *proof) verify(p Predicate, pval map[string]*abstract.Point,
-			vc VerifierContext) error {
+	vc VerifierContext) error {
 	prf.vc = vc
 	prf.pval = pval
 	prf.vp = make(map[Predicate]*verifierPred)
 
 	// Get the commitments from the verifier,
 	// and calculate the sets of responses we'll need for each OR-domain.
-	if e := p.getCommits(prf,nil); e != nil {
+	if e := p.getCommits(prf, nil); e != nil {
 		return e
 	}
 
@@ -755,15 +739,15 @@ func (prf *proof) verify(p Predicate, pval map[string]*abstract.Point,
 	}
 
 	// Check all the responses and sub-challenges against the commitments.
-	return p.verify(prf,c,nil)
+	return p.verify(prf, c, nil)
 }
 
 // Produce a higher-order Prover embodying a given proof predicate.
-func (prf *proof) prover(p Predicate, sval map[string]*abstract.Secret, 
-			pval map[string]*abstract.Point,
-			choice map[Predicate]int) Prover {
+func (prf *proof) prover(p Predicate, sval map[string]*abstract.Secret,
+	pval map[string]*abstract.Point,
+	choice map[Predicate]int) Prover {
 
-	return Prover(func(ctx ProverContext)error{
+	return Prover(func(ctx ProverContext) error {
 		return prf.prove(p, sval, pval, choice, ctx)
 	})
 }
@@ -771,8 +755,7 @@ func (prf *proof) prover(p Predicate, sval map[string]*abstract.Secret,
 // Produce a higher-order Verifier embodying a given proof predicate.
 func (prf *proof) verifier(p Predicate, pval map[string]*abstract.Point) Verifier {
 
-	return Verifier(func(ctx VerifierContext)error{
+	return Verifier(func(ctx VerifierContext) error {
 		return prf.verify(p, pval, ctx)
 	})
 }
-

--- a/proof/proof_test.go
+++ b/proof/proof_test.go
@@ -50,8 +50,8 @@ func TestRep(t *testing.T) {
 	pred := Or(or1x, or2x)
 	choice[pred] = 0
 
-	sval := map[string]abstract.Secret{"x": x, "y": y}
-	pval := map[string]abstract.Point{"B": B, "X": X, "Y": Y, "R": R}
+	sval := map[string]*abstract.Secret{"x": x, "y": y}
+	pval := map[string]*abstract.Point{"B": B, "X": X, "Y": Y, "R": R}
 	prover := pred.Prover(suite, sval, pval, choice)
 	proof, err := HashProve(suite, "TEST", rand, prover)
 	if err != nil {
@@ -93,8 +93,8 @@ func ExampleRep_2() {
 	X := suite.Point().Mul(nil, x) // corresponding public key X
 
 	// Generate a proof that we know the discrete logarithm of X.
-	sval := map[string]abstract.Secret{"x": x}
-	pval := map[string]abstract.Point{"B": B, "X": X}
+	sval := map[string]*abstract.Secret{"x": x}
+	pval := map[string]*abstract.Point{"B": B, "X": X}
 	prover := pred.Prover(suite, sval, pval, nil)
 	proof, _ := HashProve(suite, "TEST", rand, prover)
 	fmt.Print("Proof:\n" + hex.Dump(proof))
@@ -214,8 +214,8 @@ func ExampleOr_2() {
 	choice[pred] = 0
 
 	// Generate a proof that we know the discrete logarithm of X or Y.
-	sval := map[string]abstract.Secret{"x": x}
-	pval := map[string]abstract.Point{"B": B, "X": X, "Y": Y}
+	sval := map[string]*abstract.Secret{"x": x}
+	pval := map[string]*abstract.Point{"B": B, "X": X, "Y": Y}
 	prover := pred.Prover(suite, sval, pval, choice)
 	proof, _ := HashProve(suite, "TEST", rand, prover)
 	fmt.Print("Proof:\n" + hex.Dump(proof))

--- a/shuffle/biffle.go
+++ b/shuffle/biffle.go
@@ -27,10 +27,10 @@ func bifflePred() proof.Predicate {
 	return or
 }
 
-func bifflePoints(suite abstract.Suite, G, H abstract.Point,
-	X, Y, Xbar, Ybar [2]abstract.Point) map[string]abstract.Point {
+func bifflePoints(suite abstract.Suite, G, H *abstract.Point,
+	X, Y, Xbar, Ybar [2]*abstract.Point) map[string]*abstract.Point {
 
-	return map[string]abstract.Point{
+	return map[string]*abstract.Point{
 		"G":        G,
 		"H":        H,
 		"Xbar0-X0": suite.Point().Sub(Xbar[0], X[0]),
@@ -44,15 +44,15 @@ func bifflePoints(suite abstract.Suite, G, H abstract.Point,
 }
 
 // Binary shuffle ("biffle") for 2 ciphertexts based on general ZKPs.
-func Biffle(suite abstract.Suite, G, H abstract.Point,
-	X, Y [2]abstract.Point, rand abstract.Cipher) (
-	Xbar, Ybar [2]abstract.Point, prover proof.Prover) {
+func Biffle(suite abstract.Suite, G, H *abstract.Point,
+	X, Y [2]*abstract.Point, rand abstract.Cipher) (
+	Xbar, Ybar [2]*abstract.Point, prover proof.Prover) {
 
 	// Pick the single-bit permutation.
 	bit := int(random.Byte(rand) & 1)
 
 	// Pick a fresh ElGamal blinding factor for each pair
-	var beta [2]abstract.Secret
+	var beta [2]*abstract.Secret
 	for i := 0; i < 2; i++ {
 		beta[i] = suite.Secret().Pick(rand)
 	}
@@ -67,7 +67,7 @@ func Biffle(suite abstract.Suite, G, H abstract.Point,
 	}
 
 	or := bifflePred()
-	secrets := map[string]abstract.Secret{
+	secrets := map[string]*abstract.Secret{
 		"beta0": beta[0],
 		"beta1": beta[1]}
 	points := bifflePoints(suite, G, H, X, Y, Xbar, Ybar)
@@ -76,8 +76,8 @@ func Biffle(suite abstract.Suite, G, H abstract.Point,
 	return
 }
 
-func BiffleVerifier(suite abstract.Suite, G, H abstract.Point,
-	X, Y, Xbar, Ybar [2]abstract.Point) (
+func BiffleVerifier(suite abstract.Suite, G, H *abstract.Point,
+	X, Y, Xbar, Ybar [2]*abstract.Point) (
 	verifier proof.Verifier) {
 
 	or := bifflePred()
@@ -94,8 +94,8 @@ func BiffleTest(suite abstract.Suite, N int) {
 	H := suite.Point().Mul(nil, h)
 
 	// Create a set of ephemeral "client" keypairs to shuffle
-	var c [2]abstract.Secret
-	var C [2]abstract.Point
+	var c [2]*abstract.Secret
+	var C [2]*abstract.Point
 	//	fmt.Println("\nclient keys:")
 	for i := 0; i < 2; i++ {
 		c[i] = suite.Secret().Pick(rand)
@@ -104,7 +104,7 @@ func BiffleTest(suite abstract.Suite, N int) {
 	}
 
 	// ElGamal-encrypt all these keypairs with the "server" key
-	var X, Y [2]abstract.Point
+	var X, Y [2]*abstract.Point
 	r := suite.Secret() // temporary
 	for i := 0; i < 2; i++ {
 		r.Pick(rand)

--- a/shuffle/test.go
+++ b/shuffle/test.go
@@ -16,8 +16,8 @@ func TestShuffle(suite abstract.Suite, k int, N int) {
 	H := suite.Point().Mul(nil, h)
 
 	// Create a set of ephemeral "client" keypairs to shuffle
-	c := make([]abstract.Secret, k)
-	C := make([]abstract.Point, k)
+	c := make([]*abstract.Secret, k)
+	C := make([]*abstract.Point, k)
 	//	fmt.Println("\nclient keys:")
 	for i := 0; i < k; i++ {
 		c[i] = suite.Secret().Pick(rand)
@@ -26,8 +26,8 @@ func TestShuffle(suite abstract.Suite, k int, N int) {
 	}
 
 	// ElGamal-encrypt all these keypairs with the "server" key
-	X := make([]abstract.Point, k)
-	Y := make([]abstract.Point, k)
+	X := make([]*abstract.Point, k)
+	Y := make([]*abstract.Point, k)
 	r := suite.Secret() // temporary
 	for i := 0; i < k; i++ {
 		r.Pick(rand)

--- a/sig_test.go
+++ b/sig_test.go
@@ -12,12 +12,12 @@ import (
 
 // A basic, verifiable signature
 type basicSig struct {
-	C abstract.Secret // challenge
-	R abstract.Secret // response
+	C *abstract.Secret // challenge
+	R *abstract.Secret // response
 }
 
 // Returns a secret that depends on on a message and a point
-func hashSchnorr(suite abstract.Suite, message []byte, p abstract.Point) abstract.Secret {
+func hashSchnorr(suite abstract.Suite, message []byte, p *abstract.Point) *abstract.Secret {
 	pb, _ := p.MarshalBinary()
 	c := suite.Cipher(pb)
 	c.Message(nil, nil, message)
@@ -29,7 +29,7 @@ func hashSchnorr(suite abstract.Suite, message []byte, p abstract.Point) abstrac
 // The ring structure is removed and
 // The anonimity set is reduced to one public key = no anonimity
 func SchnorrSign(suite abstract.Suite, random cipher.Stream, message []byte,
-	privateKey abstract.Secret) []byte {
+	privateKey *abstract.Secret) []byte {
 
 	// Create random secret v and public point commitment T
 	v := suite.Secret().Pick(random)
@@ -51,7 +51,7 @@ func SchnorrSign(suite abstract.Suite, random cipher.Stream, message []byte,
 	return buf.Bytes()
 }
 
-func SchnorrVerify(suite abstract.Suite, message []byte, publicKey abstract.Point,
+func SchnorrVerify(suite abstract.Suite, message []byte, publicKey *abstract.Point,
 	signatureBuffer []byte) error {
 
 	// Decode the signature
@@ -64,7 +64,7 @@ func SchnorrVerify(suite abstract.Suite, message []byte, publicKey abstract.Poin
 	c := sig.C
 
 	// Compute base**(r + x*c) == T
-	var P, T abstract.Point
+	var P, T *abstract.Point
 	P = suite.Point()
 	T = suite.Point()
 	T.Add(T.Mul(nil, r), P.Mul(publicKey, c))

--- a/sodium/blake2/blake2.go
+++ b/sodium/blake2/blake2.go
@@ -14,32 +14,31 @@ import (
 	"unsafe"
 )
 
-const Blake2bBlockBytes		= 128
-const Blake2bOutBytes		= 64
-const Blake2bKeyBytes		= 64
-const Blake2bSaltBytes		= 16
-const Blake2bPersonalBytes	= 16
+const Blake2bBlockBytes = 128
+const Blake2bOutBytes = 64
+const Blake2bKeyBytes = 64
+const Blake2bSaltBytes = 16
+const Blake2bPersonalBytes = 16
 
 type Blake2bParam struct {
-	digestLength	uint8				// 1
-	keyLength	uint8				// 2
-	fanout		uint8				// 3
-	depth		uint8				// 4
-	leafLength	uint32				// 8
-	nodeOffset	uint64				// 16
-	nodeDepth	uint8				// 17
-	innerLength	uint8				// 18
-	_		[14]byte			// 32
-	salt		[Blake2bSaltBytes]byte		// 48
-	personal	[Blake2bPersonalBytes]byte	// 64
+	digestLength uint8                      // 1
+	keyLength    uint8                      // 2
+	fanout       uint8                      // 3
+	depth        uint8                      // 4
+	leafLength   uint32                     // 8
+	nodeOffset   uint64                     // 16
+	nodeDepth    uint8                      // 17
+	innerLength  uint8                      // 18
+	_            [14]byte                   // 32
+	salt         [Blake2bSaltBytes]byte     // 48
+	personal     [Blake2bPersonalBytes]byte // 64
 }
-
 
 type Blake2bState struct {
 	s C.blake2b_state
 
 	// Initialization parameters, saved for Hash.Reset()
-	key []byte
+	key   []byte
 	param *Blake2bParam
 }
 
@@ -57,7 +56,7 @@ func (s *Blake2bState) Init(key []byte, param *Blake2bParam) {
 		C.blake2b_init(&s.s, Blake2bOutBytes)
 	} else {
 		C.blake2b_init_param(&s.s,
-				(*C.blake2b_param)(unsafe.Pointer(param)))
+			(*C.blake2b_param)(unsafe.Pointer(param)))
 	}
 
 	// If key was provided, use it as the first data block to hash.
@@ -68,8 +67,8 @@ func (s *Blake2bState) Init(key []byte, param *Blake2bParam) {
 		var block [Blake2bBlockBytes]byte
 		copy(block[:], key)
 		s.Write(block[:])
-		for i := range(block) {
-			block[i] = 0	// erase key from temporary block
+		for i := range block {
+			block[i] = 0 // erase key from temporary block
 		}
 	}
 }
@@ -85,8 +84,8 @@ func (s *Blake2bState) Reset() {
 func (s *Blake2bState) Write(p []byte) (n int, err error) {
 	l := len(p)
 	C.blake2b_update(&s.s, (*C.uint8_t)(unsafe.Pointer(&p[0])),
-			C.uint64_t(l))
-	return l,nil
+		C.uint64_t(l))
+	return l, nil
 }
 
 func (s *Blake2bState) Size() int {
@@ -106,16 +105,12 @@ func (s *Blake2bState) Sum(b []byte) []byte {
 
 	var d [Blake2bOutBytes]byte
 	if C.blake2b_final(&st, (*C.uint8_t)(unsafe.Pointer(&d[0])),
-				C.uint8_t(Blake2bOutBytes)) != 0 {
+		C.uint8_t(Blake2bOutBytes)) != 0 {
 		panic("blake2b_final failed")
 	}
 	return append(b, d[:]...)
 }
 
-
-
 // Implementation of the cipher.Stream interface
 //func (h *Blake2bState) XORKeyStream(dst,src []byte) {
 //}
-
-

--- a/sodium/doc.go
+++ b/sodium/doc.go
@@ -4,7 +4,7 @@
 Package sodium contains functionality ported from the Sodium crypto library.
 See http://doc.libsodium.org for background and details on Sodium.
 
-Currently all of the code in these Sodium-derived sub-packages 
+Currently all of the code in these Sodium-derived sub-packages
 are extremely experimental and may (or may not) go away in the future.
 These consist of alternative implementations of functionality
 that is also implemented in other ways in other parts of the library;

--- a/sodium/ed25519/curve.go
+++ b/sodium/ed25519/curve.go
@@ -83,16 +83,16 @@ func (p *point) String() string {
 	return hex.EncodeToString(p.Encode())
 }
 
-func (p *point) Equal(p2 abstract.Point) bool {
+func (p *point) Equal(p2 *abstract.Point) bool {
 	return bytes.Equal(p.Encode(), p2.(*point).Encode())
 }
 
-func (p *point) Null() abstract.Point {
+func (p *point) Null() *abstract.Point {
 	C.ge_p3_0(&p.p)
 	return p
 }
 
-func (p *point) Base() abstract.Point {
+func (p *point) Base() *abstract.Point {
 
 	// Way to kill a fly with a sledgehammer...
 	C.ge_scalarmult_base(&p.p, (*C.uchar)(unsafe.Pointer(&s1.b[0])))
@@ -106,7 +106,7 @@ func (p *point) PickLen() int {
 	return (255 - 8 - 8) / 8
 }
 
-func (P *point) Pick(data []byte, rand cipher.Stream) (abstract.Point, []byte) {
+func (P *point) Pick(data []byte, rand cipher.Stream) (*abstract.Point, []byte) {
 
 	// How many bytes to embed?
 	dl := P.PickLen()
@@ -163,27 +163,27 @@ func (p *point) Data() ([]byte, error) {
 	return b[1 : 1+dl], nil
 }
 
-func (p *point) Add(ca, cb abstract.Point) abstract.Point {
+func (p *point) Add(ca, cb *abstract.Point) *abstract.Point {
 	a := ca.(*point)
 	b := cb.(*point)
 	C.ge_p3_add(&p.p, &a.p, &b.p)
 	return p
 }
 
-func (p *point) Sub(ca, cb abstract.Point) abstract.Point {
+func (p *point) Sub(ca, cb *abstract.Point) *abstract.Point {
 	a := ca.(*point)
 	b := cb.(*point)
 	C.ge_p3_sub(&p.p, &a.p, &b.p)
 	return p
 }
 
-func (p *point) Neg(ca abstract.Point) abstract.Point {
+func (p *point) Neg(ca *abstract.Point) *abstract.Point {
 	a := ca.(*point)
 	C.ge_p3_neg(&p.p, &a.p)
 	return p
 }
 
-func (p *point) Mul(ca abstract.Point, cs abstract.Secret) abstract.Point {
+func (p *point) Mul(ca *abstract.Point, cs *abstract.Secret) *abstract.Point {
 
 	// Convert the scalar to fixed-length little-endian form.
 	sb := cs.(*nist.Int).V.Bytes()
@@ -263,7 +263,7 @@ func (c *curve) SecretLen() int {
 	return 32
 }
 
-func (c *curve) Secret() abstract.Secret {
+func (c *curve) Secret() *abstract.Secret {
 	return nist.NewInt(0, &primeOrder.V)
 }
 
@@ -271,7 +271,7 @@ func (c *curve) PointLen() int {
 	return 32
 }
 
-func (c *curve) Point() abstract.Point {
+func (c *curve) Point() *abstract.Point {
 	return new(point)
 }
 

--- a/sodium/ed25519/curve_test.go
+++ b/sodium/ed25519/curve_test.go
@@ -3,17 +3,15 @@
 package ed25519
 
 import (
-	"testing"
 	"github.com/dedis/crypto/test"
+	"testing"
 )
 
 var testSuite = NewAES128SHA256Ed25519()
 
-
 func TestGroup(t *testing.T) {
 	test.TestSuite(testSuite)
 }
-
 
 func BenchmarkSecretAdd(b *testing.B) {
 	test.NewGroupBench(testSuite).SecretAdd(b.N)
@@ -51,7 +49,6 @@ func BenchmarkSecretDecode(b *testing.B) {
 	test.NewGroupBench(testSuite).SecretDecode(b.N)
 }
 
-
 func BenchmarkPointAdd(b *testing.B) {
 	test.NewGroupBench(testSuite).PointAdd(b.N)
 }
@@ -83,4 +80,3 @@ func BenchmarkPointEncode(b *testing.B) {
 func BenchmarkPointDecode(b *testing.B) {
 	test.NewGroupBench(testSuite).PointDecode(b.N)
 }
-

--- a/sodium/ed25519/secret.go
+++ b/sodium/ed25519/secret.go
@@ -27,7 +27,7 @@ var s2 = secret{[32]byte{2}}
 var s3 = secret{[32]byte{3}}
 var s4 = secret{[32]byte{4}}
 
-func (s *secret) Set(s2 abstract.Secret) abstract.Secret {
+func (s *secret) Set(s2 *abstract.Secret) *abstract.Secret {
 	s.b = s2.(*secret).b
 	return s
 }
@@ -57,23 +57,23 @@ func (s *secret) UnmarshalFrom(r io.Reader) (int, error) {
 	return group.SecretUnmarshalFrom(s, r)
 }
 
-func (s *secret) Zero() abstract.Secret {
+func (s *secret) Zero() *abstract.Secret {
 	panic("XXX")
 }
 
-func (s *secret) One() abstract.Secret {
+func (s *secret) One() *abstract.Secret {
 	panic("XXX")
 }
 
-func (s *secret) SetInt64(v int64) abstract.Secret {
+func (s *secret) SetInt64(v int64) *abstract.Secret {
 	panic("XXX")
 }
 
-func (s *secret) Equal(s2 abstract.Secret) bool {
+func (s *secret) Equal(s2 *abstract.Secret) bool {
 	return bytes.Equal(s.b[:], s2.(*secret).b[:])
 }
 
-func (s *secret) Add(cx, cy abstract.Secret) abstract.Secret {
+func (s *secret) Add(cx, cy *abstract.Secret) *abstract.Secret {
 	x := cx.(*secret)
 	y := cy.(*secret)
 
@@ -86,27 +86,27 @@ func (s *secret) Add(cx, cy abstract.Secret) abstract.Secret {
 	return s
 }
 
-func (s *secret) Sub(cx, cy abstract.Secret) abstract.Secret {
+func (s *secret) Sub(cx, cy *abstract.Secret) *abstract.Secret {
 	panic("XXX")
 }
 
-func (s *secret) Neg(x abstract.Secret) abstract.Secret {
+func (s *secret) Neg(x *abstract.Secret) *abstract.Secret {
 	panic("XXX")
 }
 
-func (s *secret) Mul(cx, cy abstract.Secret) abstract.Secret {
+func (s *secret) Mul(cx, cy *abstract.Secret) *abstract.Secret {
 	panic("XXX")
 }
 
-func (s *secret) Div(cx, cy abstract.Secret) abstract.Secret {
+func (s *secret) Div(cx, cy *abstract.Secret) *abstract.Secret {
 	panic("XXX")
 }
 
-func (s *secret) Inv(x abstract.Secret) abstract.Secret {
+func (s *secret) Inv(x *abstract.Secret) *abstract.Secret {
 	panic("XXX")
 }
 
-func (s *secret) Pick(rand cipher.Stream) abstract.Secret {
+func (s *secret) Pick(rand cipher.Stream) *abstract.Secret {
 	rand.XORKeyStream(s.b[:], s.b[:])
 	s.b[0] &= 248
 	s.b[31] &= 63

--- a/test/doc.go
+++ b/test/doc.go
@@ -1,4 +1,3 @@
 // Package test contains generic testing and benchmarking infrastructure
 // for cryptographic groups and ciphersuites.
 package test
-

--- a/test/group.go
+++ b/test/group.go
@@ -10,8 +10,8 @@ type GroupBench struct {
 	g abstract.Group
 
 	// Random secrets and points for testing
-	x, y abstract.Secret
-	X, Y abstract.Point
+	x, y *abstract.Secret
+	X, Y *abstract.Point
 	xe   []byte // encoded Secret
 	Xe   []byte // encoded Point
 }

--- a/test/test.go
+++ b/test/test.go
@@ -3,9 +3,10 @@ package test
 import (
 	"bytes"
 	"crypto/cipher"
-
+	"encoding/gob"
 	"github.com/dedis/crypto/abstract"
 	"github.com/dedis/crypto/random"
+	"log"
 )
 
 func testEmbed(g abstract.Group, rand cipher.Stream, points *[]*abstract.Point,
@@ -205,6 +206,23 @@ func testGroup(g abstract.Group, rand cipher.Stream) []*abstract.Point {
 	err := repzero.UnmarshalBinary(b)
 	if err != nil {
 		panic(err)
+	}
+
+	// Test direct marshaling/unmarshaling
+	secret_src := g.Secret().Pick(rand)
+	log.Printf("Group: %+v - Src: %+v\n", g, secret_src)
+	var network bytes.Buffer
+	enc := gob.NewEncoder(&network)
+	err = enc.Encode(secret_src)
+	if err != nil {
+		log.Fatal("encode:", err)
+	}
+	log.Printf("Encoded: %+v\n", network.Bytes())
+	dec := gob.NewDecoder(&network)
+	var t abstract.Secret
+	err = dec.Decode(&t)
+	if err != nil {
+		log.Fatal("decode:", err)
 	}
 
 	return points

--- a/test/test.go
+++ b/test/test.go
@@ -208,19 +208,30 @@ func testGroup(g abstract.Group, rand cipher.Stream) []*abstract.Point {
 		panic(err)
 	}
 
-	// Test direct marshaling/unmarshaling
+	// Test direct marshaling/unmarshaling of Secrets
 	secret_src := g.Secret().Pick(rand)
-	log.Printf("Group: %+v - Src: %+v\n", g, secret_src)
 	var network bytes.Buffer
 	enc := gob.NewEncoder(&network)
 	err = enc.Encode(secret_src)
 	if err != nil {
 		log.Fatal("encode:", err)
 	}
-	log.Printf("Encoded: %+v\n", network.Bytes())
 	dec := gob.NewDecoder(&network)
-	var t abstract.Secret
-	err = dec.Decode(&t)
+	var secret_new abstract.Secret
+	err = dec.Decode(&secret_new)
+	if err != nil {
+		log.Fatal("decode:", err)
+	}
+
+	// Test direct marshaling/unmarshaling of Points
+	point_src := g.Point().Mul(nil, secret_src)
+	network.Reset()
+	err = enc.Encode(point_src)
+	if err != nil {
+		log.Fatal("encode:", err)
+	}
+	var point_new abstract.Point
+	err = dec.Decode(&point_new)
 	if err != nil {
 		log.Fatal("decode:", err)
 	}

--- a/test/test.go
+++ b/test/test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/dedis/crypto/random"
 )
 
-func testEmbed(g abstract.Group, rand cipher.Stream, points *[]abstract.Point,
+func testEmbed(g abstract.Group, rand cipher.Stream, points *[]*abstract.Point,
 	s string) {
 	//println("embedding: ",s)
 	b := []byte(s)
@@ -35,11 +35,11 @@ func testEmbed(g abstract.Group, rand cipher.Stream, points *[]abstract.Point,
 // for comparison across alternative implementations
 // that are supposed to be equivalent.
 //
-func testGroup(g abstract.Group, rand cipher.Stream) []abstract.Point {
+func testGroup(g abstract.Group, rand cipher.Stream) []*abstract.Point {
 	//	fmt.Printf("\nTesting group '%s': %d-byte Point, %d-byte Secret\n",
 	//			g.String(), g.PointLen(), g.SecretLen())
 
-	points := make([]abstract.Point, 0)
+	points := make([]*abstract.Point, 0)
 	ptmp := g.Point()
 	stmp := g.Secret()
 	pzero := g.Point().Null()

--- a/test/test.go
+++ b/test/test.go
@@ -277,7 +277,24 @@ func testGroup(g abstract.Group, rand cipher.Stream) []*abstract.Point {
 		log.Fatal("JSON-Points are not the same")
 	}
 
+	p_src := &BigStruct{}
+	p_src.Points = make(map[string]*abstract.Point)
+	point_src.Add(point_src, point_src)
+	p_src.Points["one"] = point_src
+	p_src.Points["two"] = point2_src
+	network.Reset()
+	encJson.Encode(p_src)
+	p_copy := &BigStruct{}
+	decJson.Decode(p_copy)
+	if !p_src.Points["one"].Equal(p_copy.Points["one"]) {
+		log.Fatal("Points are not the same in map[string]")
+	}
+
 	return points
+}
+
+type BigStruct struct {
+	Points map[string]*abstract.Point
 }
 
 // Apply a generic set of validation tests to a cryptographic Group.


### PR DESCRIPTION
This is a proof-of-concept of an auto-unmarshaling point and secret structure. 
It solves two problems with regard to unmarshaling:
- we don't know beforehand what suite we're using, so we have to write a Binary(Un)marshaler for every struct that contains abstract.Point or abstract.Secret
- as `abstract.Point` and `abstract.Secret` are interfaces, we can't use them as-is with `gob`, `protobuf`, `json` or any other marshaler, as they can't unmarshal into an interface

So I added a structure containing the interface of `abstract.Point` and `abstract.Secret` and wrote a Binary(Un)marshaler for it, so that all encoders can directly work on the structures that contain `abstract.Point` or `abstract.Secret`.

Now if you have a structure like

```
type Message struct{
   X abstract.Point
   v abstract.Secret
}
```

You don't need to write any Binary(Un)marshaler for it anymore that adds the suite and prepares the interfaces, you can just give it to any en/decoder available in Go.

This has been tested with `gob` and `json` en- and decoders.