### PR TITLE
Nist.Int.LittleEndian panics

### DIFF
--- a/nist/group_test.go
+++ b/nist/group_test.go
@@ -1,8 +1,9 @@
 package nist
 
 import (
-	"github.com/dedis/crypto/test"
 	"testing"
+
+	"github.com/dedis/crypto/test"
 )
 
 var testQR512 = NewAES128SHA256QR512()

--- a/nist/int.go
+++ b/nist/int.go
@@ -352,10 +352,10 @@ func (i *Int) BigEndian(min, max int) []byte {
 // Panics if max != 0 and the Int cannot be represented in max bytes.
 func (i *Int) LittleEndian(min, max int) []byte {
 	act := i.MarshalSize()
-	/*vSize := len(i.V.Bytes())*/
-	//if vSize < act {
-	//act = vSize
-	/*}*/
+	vSize := len(i.V.Bytes())
+	if vSize < act {
+		act = vSize
+	}
 	pad := act
 	if pad < min {
 		pad = min

--- a/nist/int.go
+++ b/nist/int.go
@@ -352,7 +352,7 @@ func (i *Int) BigEndian(min, max int) []byte {
 // Panics if max != 0 and the Int cannot be represented in max bytes.
 func (i *Int) LittleEndian(min, max int) []byte {
 	act := i.MarshalSize()
-	vSize := i.V.BitLen()
+	vSize := len(i.V.Bytes())
 	if vSize < act {
 		act = vSize
 	}

--- a/nist/int.go
+++ b/nist/int.go
@@ -352,7 +352,8 @@ func (i *Int) BigEndian(min, max int) []byte {
 // Panics if max != 0 and the Int cannot be represented in max bytes.
 func (i *Int) LittleEndian(min, max int) []byte {
 	act := i.MarshalSize()
-	vSize := len(i.V.Bytes())
+	vBytes := i.V.Bytes()
+	vSize := len(vBytes)
 	if vSize < act {
 		act = vSize
 	}
@@ -364,7 +365,7 @@ func (i *Int) LittleEndian(min, max int) []byte {
 		panic("Int not representable in max bytes")
 	}
 	buf := make([]byte, pad)
-	util.Reverse(buf[:act], i.V.Bytes())
+	util.Reverse(buf[:act], vBytes)
 	return buf
 }
 

--- a/nist/int.go
+++ b/nist/int.go
@@ -352,7 +352,7 @@ func (i *Int) BigEndian(min, max int) []byte {
 // Panics if max != 0 and the Int cannot be represented in max bytes.
 func (i *Int) LittleEndian(min, max int) []byte {
 	act := i.MarshalSize()
-	vSize := len(i.V.Bytes())
+	vSize := i.V.BitLen()
 	if vSize < act {
 		act = vSize
 	}

--- a/nist/int.go
+++ b/nist/int.go
@@ -352,10 +352,10 @@ func (i *Int) BigEndian(min, max int) []byte {
 // Panics if max != 0 and the Int cannot be represented in max bytes.
 func (i *Int) LittleEndian(min, max int) []byte {
 	act := i.MarshalSize()
-	vSize := len(i.V.Bytes())
-	if vSize < act {
-		act = vSize
-	}
+	/*vSize := len(i.V.Bytes())*/
+	//if vSize < act {
+	//act = vSize
+	/*}*/
 	pad := act
 	if pad < min {
 		pad = min

--- a/nist/int.go
+++ b/nist/int.go
@@ -4,13 +4,14 @@ import (
 	"crypto/cipher"
 	"encoding/hex"
 	"errors"
+	"io"
+	"math/big"
+
 	"github.com/dedis/crypto/abstract"
 	"github.com/dedis/crypto/group"
 	"github.com/dedis/crypto/math"
 	"github.com/dedis/crypto/random"
 	"github.com/dedis/crypto/util"
-	"io"
-	"math/big"
 )
 
 var zero = big.NewInt(0)
@@ -351,6 +352,10 @@ func (i *Int) BigEndian(min, max int) []byte {
 // Panics if max != 0 and the Int cannot be represented in max bytes.
 func (i *Int) LittleEndian(min, max int) []byte {
 	act := i.MarshalSize()
+	vSize := len(i.V.Bytes())
+	if vSize < act {
+		act = vSize
+	}
 	pad := act
 	if pad < min {
 		pad = min

--- a/nist/int_test.go
+++ b/nist/int_test.go
@@ -5,7 +5,6 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/dedis/crypto/util"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -18,10 +17,6 @@ func TestIntEndianBytes(t *testing.T) {
 
 	i := new(Int).InitBytes(v, moduloI)
 
-	buffLE := i.LittleEndian(32, 32)
-	buffBE := i.BigEndian(32, 32)
-
-	util.Reverse(buffBE, buffBE)
-
-	assert.Equal(t, buffLE, buffBE)
+	assert.Equal(t, i.MarshalSize(), 32)
+	assert.NotPanics(t, func() { i.LittleEndian(32, 32) })
 }

--- a/nist/int_test.go
+++ b/nist/int_test.go
@@ -1,0 +1,27 @@
+package nist
+
+import (
+	"encoding/hex"
+	"math/big"
+	"testing"
+
+	"github.com/dedis/crypto/util"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIntEndianBytes(t *testing.T) {
+	modulo, err := hex.DecodeString("1000000000000000000000000000000014def9dea2f79cd65812631a5cf5d3ed")
+	moduloI := new(big.Int).SetBytes(modulo)
+	assert.Nil(t, err)
+	v, err := hex.DecodeString("9e86dbc411ddeab7515cfadacc4516d00d6858a3c1ec4084c05ed27c36ada6")
+	assert.Nil(t, err)
+
+	i := new(Int).InitBytes(v, moduloI)
+
+	buffLE := i.LittleEndian(32, 32)
+	buffBE := i.BigEndian(32, 32)
+
+	util.Reverse(buffBE, buffBE)
+
+	assert.Equal(t, buffLE, buffBE)
+}

--- a/nist/int_test.go
+++ b/nist/int_test.go
@@ -9,14 +9,14 @@ import (
 )
 
 func TestIntEndianBytes(t *testing.T) {
-	modulo, err := hex.DecodeString("1000000000000000000000000000000014def9dea2f79cd65812631a5cf5d3ed")
+	modulo, err := hex.DecodeString("1000")
 	moduloI := new(big.Int).SetBytes(modulo)
 	assert.Nil(t, err)
-	v, err := hex.DecodeString("9e86dbc411ddeab7515cfadacc4516d00d6858a3c1ec4084c05ed27c36ada6")
+	v, err := hex.DecodeString("10")
 	assert.Nil(t, err)
 
 	i := new(Int).InitBytes(v, moduloI)
 
-	assert.Equal(t, i.MarshalSize(), 32)
-	assert.NotPanics(t, func() { i.LittleEndian(32, 32) })
+	assert.Equal(t, 2, i.MarshalSize())
+	assert.NotPanics(t, func() { i.LittleEndian(2, 2) })
 }

--- a/nist/qrsuite.go
+++ b/nist/qrsuite.go
@@ -2,13 +2,14 @@ package nist
 
 import (
 	"crypto/sha256"
-	"github.com/dedis/crypto/abstract"
-	"github.com/dedis/crypto/cipher/sha3"
-	"github.com/dedis/crypto/random"
 	"hash"
 	"io"
 	"math/big"
 	"reflect"
+
+	"github.com/dedis/crypto/abstract"
+	"github.com/dedis/crypto/cipher/sha3"
+	"github.com/dedis/crypto/random"
 )
 
 type qrsuite struct {

--- a/nist/suite.go
+++ b/nist/suite.go
@@ -2,11 +2,12 @@ package nist
 
 import (
 	"crypto/sha256"
-	"github.com/dedis/crypto/abstract"
-	"github.com/dedis/crypto/cipher/sha3"
 	"hash"
 	"io"
 	"reflect"
+
+	"github.com/dedis/crypto/abstract"
+	"github.com/dedis/crypto/cipher/sha3"
 )
 
 type suite128 struct {


### PR DESCRIPTION
In the LittleEndian(min,max) function, there can be a case where it panics whereas it may not have to.
Here is an example (with hex-encoded value):
```
Trying buf[:32] vs len(V.Bytes()) = 31
i.MarshalSize = 32
i.V.Bytes() :  9e86dbc411ddeab7515cfadacc4516d00d6858a3c1ec4084c05ed27c36ada6
i.M.Bytes() : 1000000000000000000000000000000014def9dea2f79cd65812631a5cf5d3ed
```
Here it panics because it tries to call `util.Reverse(buf[:32],i.V.Bytes())` where `len(i.V.Bytes()) == 31`.
The thing is that the function checks against the Modulo size and assume it is the same size for the value, but it's not always the case.

