### PR TITLE
anon test fixed -> duplicating fields

### DIFF
--- a/anon/sig_test.go
+++ b/anon/sig_test.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
+	"testing"
+
 	"github.com/dedis/crypto/abstract"
 	"github.com/dedis/crypto/edwards"
 	"github.com/dedis/crypto/nist"
 	"github.com/dedis/crypto/random"
-	"testing"
 )
 
 // This example demonstrates signing and signature verification


### PR DESCRIPTION
Using unexported fiels don't work with the current abstract.Read/Write methods. Either putting `anon/uSig` as public or duplicating the fields of `anon/uSig` into `anon/lSig`.
I chose to duplicate them as to keep the API clean, even if the code is less (~ still less than 10 lines of codes)
It's a hotfix  for an issue that should be scrutinized further ! See https://github.com/dedis/crypto/issues/81