### PR TITLE
Fixing nist.Int.Clone()

### DIFF
--- a/ed25519/const.go
+++ b/ed25519/const.go
@@ -17,7 +17,7 @@ var prime, _ = new(big.Int).SetString("57896044618658097711785492504343953926634
 var primeOrder, _ = new(nist.Int).SetString("7237005577332262213973186563042994240857116359379907606001950938285454250989", "", 10)
 
 // cofactor of the curve, as a ModInt
-var cofactor = nist.NewInt(8, &primeOrder.V)
+var cofactor = nist.NewInt64(8, &primeOrder.V)
 
 // order of the full curve including the cofactor
 var fullOrder = new(big.Int).Mul(&primeOrder.V, &cofactor.V)

--- a/ed25519/curve_test.go
+++ b/ed25519/curve_test.go
@@ -3,6 +3,7 @@ package ed25519
 import (
 	"testing"
 
+	"github.com/dedis/cothority/log"
 	"github.com/dedis/crypto/test"
 )
 
@@ -29,3 +30,11 @@ func BenchmarkPointBaseMul(b *testing.B) { groupBench.PointBaseMul(b.N) }
 func BenchmarkPointPick(b *testing.B)    { groupBench.PointPick(b.N) }
 func BenchmarkPointEncode(b *testing.B)  { groupBench.PointEncode(b.N) }
 func BenchmarkPointDecode(b *testing.B)  { groupBench.PointDecode(b.N) }
+
+func TestClone(t *testing.T) {
+	suite := NewAES128SHA256Ed25519(false)
+	a := suite.Scalar().One()
+	b := a.Clone()
+	b.Add(b, b)
+	log.Print(a, b)
+}

--- a/ed25519/point.go
+++ b/ed25519/point.go
@@ -260,7 +260,7 @@ func (c *Curve) Scalar() abstract.Scalar {
 	//	if c.FullGroup {
 	//		return nist.NewInt(0, fullOrder)
 	//	} else {
-	i := nist.NewInt(0, &primeOrder.V)
+	i := nist.NewInt64(0, &primeOrder.V)
 	i.BO = nist.LittleEndian
 	return i
 	//	}

--- a/edwards/basic.go
+++ b/edwards/basic.go
@@ -34,7 +34,7 @@ func (P *basicPoint) String() string {
 // Create a new ModInt representing a coordinate on this curve,
 // with a given int64 integer value for constant-initialization convenience.
 func (P *basicPoint) coord(v int64) *nist.Int {
-	return nist.NewInt(v, &P.c.P)
+	return nist.NewInt64(v, &P.c.P)
 }
 
 func (P *basicPoint) MarshalSize() int {

--- a/edwards/curve.go
+++ b/edwards/curve.go
@@ -60,7 +60,7 @@ func (c *curve) ScalarLen() int {
 
 // Create a new Scalar for this curve.
 func (c *curve) Scalar() abstract.Scalar {
-	return nist.NewInt(0, &c.order.V)
+	return nist.NewInt64(0, &c.order.V)
 }
 
 // Returns the size in bytes of an encoded Point on this curve.

--- a/nist/curve.go
+++ b/nist/curve.go
@@ -230,7 +230,7 @@ func (c *curve) ScalarLen() int { return (c.p.N.BitLen() + 7) / 8 }
 
 // Create a Scalar associated with this curve.
 func (c *curve) Scalar() abstract.Scalar {
-	return NewInt(0, c.p.N)
+	return NewInt64(0, c.p.N)
 }
 
 // Number of bytes required to store one coordinate on this curve

--- a/nist/int.go
+++ b/nist/int.go
@@ -140,7 +140,10 @@ func (i *Int) Set(a abstract.Scalar) abstract.Scalar {
 }
 
 func (i *Int) Clone() abstract.Scalar {
-	return &Int{V: i.V, M: i.M, BO: i.BO}
+	v := new(big.Int).Set(&i.V)
+	m := new(big.Int).Set(i.M)
+	return &Int{V: *v, M: m, BO: i.BO}
+	//return &Int{V: I->V, M: i.M, BO: i.BO}
 }
 
 // Set to the value 0.  The modulus must already be initialized.

--- a/nist/int.go
+++ b/nist/int.go
@@ -143,7 +143,6 @@ func (i *Int) Clone() abstract.Scalar {
 	v := new(big.Int).Set(&i.V)
 	m := new(big.Int).Set(i.M)
 	return &Int{V: *v, M: m, BO: i.BO}
-	//return &Int{V: I->V, M: i.M, BO: i.BO}
 }
 
 // Set to the value 0.  The modulus must already be initialized.

--- a/nist/int.go
+++ b/nist/int.go
@@ -50,8 +50,15 @@ type Int struct {
 }
 
 // Create a new Int with a given int64 value and big.Int modulus.
-func NewInt(v int64, M *big.Int) *Int {
+func NewInt64(v int64, M *big.Int) *Int {
 	return new(Int).Init64(v, M)
+}
+
+// Create a new Int with a big.Int.
+func NewInt(v *big.Int, m *big.Int, bo ByteOrder) *Int {
+	i := new(Int).Init(v, m)
+	i.BO = bo
+	return i
 }
 
 // Initialize a Int with a given big.Int value and modulus pointer.
@@ -140,9 +147,12 @@ func (i *Int) Set(a abstract.Scalar) abstract.Scalar {
 }
 
 func (i *Int) Clone() abstract.Scalar {
-	v := new(big.Int).Set(&i.V)
-	m := new(big.Int).Set(i.M)
-	return &Int{V: *v, M: m, BO: i.BO}
+	//v := new(big.Int).Set(&i.V)
+	//m := new(big.Int).Set(i.M)
+	//return &Int{V: *v, M: m, BO: i.BO}
+	//return &Int{V: i.V, M: i.M, BO: i.BO}
+	//return new(Int).Init(&i.V, i.M)
+	return NewInt(&i.V, i.M, i.BO)
 }
 
 // Set to the value 0.  The modulus must already be initialized.

--- a/nist/int_test.go
+++ b/nist/int_test.go
@@ -63,3 +63,22 @@ func TestIntEndianBytes(t *testing.T) {
 	assert.Equal(t, 2, i.MarshalSize())
 	assert.NotPanics(t, func() { i.LittleEndian(2, 2) })
 }
+
+func TestIntClone(t *testing.T) {
+	modulo, err := hex.DecodeString("1000")
+	moduloI := new(big.Int).SetBytes(modulo)
+	assert.Nil(t, err)
+	v, err := hex.DecodeString("10")
+	assert.Nil(t, err)
+
+	base := new(Int).InitBytes(v, moduloI)
+
+	for i := 0; i < 10; i++ {
+		clone := base.Clone()
+		clone.Add(base, clone)
+		if clone.Equal(base) {
+			t.Error("Should not be equal")
+		}
+	}
+
+}

--- a/nist/int_test.go
+++ b/nist/int_test.go
@@ -5,6 +5,8 @@ import (
 	"math/big"
 	"testing"
 
+	"bytes"
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -36,7 +38,7 @@ func TestIntEndianness(t *testing.T) {
 
 	// Try to reconstruct the int from the buffer
 	i = new(Int).Init64(v, modulo)
-	i2 := NewInt(0, modulo)
+	i2 := NewInt64(0, modulo)
 	buff, _ := i.MarshalBinary()
 	assert.Nil(t, i2.UnmarshalBinary(buff))
 	assert.True(t, i.Equal(i2))
@@ -65,20 +67,12 @@ func TestIntEndianBytes(t *testing.T) {
 }
 
 func TestIntClone(t *testing.T) {
-	modulo, err := hex.DecodeString("1000")
-	moduloI := new(big.Int).SetBytes(modulo)
-	assert.Nil(t, err)
-	v, err := hex.DecodeString("10")
-	assert.Nil(t, err)
+	moduloI := new(big.Int).SetBytes([]byte{0x10, 0})
+	base := new(Int).InitBytes([]byte{0x10}, moduloI)
 
-	base := new(Int).InitBytes(v, moduloI)
-
-	for i := 0; i < 10; i++ {
-		clone := base.Clone()
-		clone.Add(base, clone)
-		if clone.Equal(base) {
-			t.Error("Should not be equal")
-		}
+	clone := base.Clone()
+	clone.Add(clone, clone)
+	if bytes.Compare(clone.Bytes(), base.Bytes()) == 0 {
+		t.Error("Should not be equal")
 	}
-
 }

--- a/nist/residue.go
+++ b/nist/residue.go
@@ -202,7 +202,7 @@ func (g *ResidueGroup) ScalarLen() int { return (g.Q.BitLen() + 7) / 8 }
 // Create a Scalar associated with this Residue group,
 // with an initial value of nil.
 func (g *ResidueGroup) Scalar() abstract.Scalar {
-	return NewInt(0, g.Q)
+	return NewInt64(0, g.Q)
 }
 
 // Return the number of bytes in the encoding of a Point

--- a/sodium/ed25519/curve.go
+++ b/sodium/ed25519/curve.go
@@ -60,7 +60,7 @@ import (
 var primeOrder, _ = new(nist.Int).SetString("7237005577332262213973186563042994240857116359379907606001950938285454250989", "", 10)
 
 // curve's cofactor
-var cofactor = nist.NewInt(8, &primeOrder.V)
+var cofactor = nist.NewInt64(8, &primeOrder.V)
 
 var nullPoint = new(point).Null()
 
@@ -265,7 +265,7 @@ func (c *curve) ScalarLen() int {
 }
 
 func (c *curve) Scalar() abstract.Scalar {
-	return nist.NewInt(0, &primeOrder.V)
+	return nist.NewInt64(0, &primeOrder.V)
 }
 
 func (c *curve) PointLen() int {


### PR DESCRIPTION
Value was copied but value is a big.Int which contains the real value which is a slice (i.e. pointer).