### PR TITLE
 [Refactoring] Discrete Log Equality zero knowledge proof

### DIFF
--- a/hash/hash.go
+++ b/hash/hash.go
@@ -1,0 +1,101 @@
+// Package hash provides utility functions to process complex data types, like
+// data streams, files, or sequences of structs of different types.
+package hash
+
+import (
+	"bytes"
+	"errors"
+	h "hash"
+	"io"
+	"os"
+
+	"encoding"
+	"reflect"
+)
+
+var defaultChunkSize = 1024
+
+// Stream returns the hash of a data stream separated into chunks of the defaultChunkSize.
+func Stream(hash h.Hash, stream io.Reader) ([]byte, error) {
+	return StreamChunk(hash, stream, defaultChunkSize)
+}
+
+// StreamChunk returns the hash of a data stream separated into chunks of the given byte size.
+func StreamChunk(hash h.Hash, stream io.Reader, size int) ([]byte, error) {
+	if size < 1 {
+		return nil, errors.New("Invalid chunk size")
+	}
+	b := make([]byte, size)
+	for {
+		n, errRead := stream.Read(b)
+		_, err := hash.Write(b[:n])
+		if err != nil {
+			return nil, err
+		}
+		if errRead == io.EOF || n < size {
+			break
+		}
+	}
+	return hash.Sum(nil), nil
+}
+
+// File returns the hash of a file processed as a data stream of chunks of the defaultChunkSize.
+func File(hash h.Hash, stream io.Reader) ([]byte, error) {
+	return StreamChunk(hash, stream, defaultChunkSize)
+}
+
+// FileChunk returns the hash of a file processed as a data stream of chunks with the given byte size.
+func FileChunk(hash h.Hash, file string, size int) ([]byte, error) {
+	f, err := os.Open(file)
+	if err != nil {
+		return nil, err
+	}
+	return StreamChunk(hash, f, size)
+}
+
+// Args returns the hash of all the given arguments. Each argument has to
+// implement the BinaryMarshaler interface.
+func Args(hash h.Hash, args ...interface{}) ([]byte, error) {
+	var res, buf []byte
+	bmArgs, err := convertToBinaryMarshaler(args)
+	if err != nil {
+		return nil, err
+	}
+	for _, a := range bmArgs {
+		buf, err = a.MarshalBinary()
+		if err != nil {
+			return nil, err
+		}
+		res, err = Stream(hash, bytes.NewReader(buf))
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+// convertToBinaryMarshaler takes a slice of interfaces and returns
+// a slice of BinaryMarshalers.
+func convertToBinaryMarshaler(args ...interface{}) ([]encoding.BinaryMarshaler, error) {
+	var ret []encoding.BinaryMarshaler
+	for _, a := range args {
+		refl := reflect.ValueOf(a)
+		if refl.Kind() == reflect.Slice {
+			for b := 0; b < refl.Len(); b++ {
+				el := refl.Index(b)
+				bms, err := convertToBinaryMarshaler(el.Interface())
+				if err != nil {
+					return nil, err
+				}
+				ret = append(ret, bms...)
+			}
+		} else {
+			bm, ok := a.(encoding.BinaryMarshaler)
+			if !ok {
+				return nil, errors.New("Could not convert to BinaryMarshaler")
+			}
+			ret = append(ret, bm)
+		}
+	}
+	return ret, nil
+}

--- a/hash/hash_test.go
+++ b/hash/hash_test.go
@@ -1,0 +1,120 @@
+package hash_test
+
+import (
+	"bytes"
+	"crypto/rand"
+	"io/ioutil"
+	"testing"
+
+	"os"
+
+	"github.com/dedis/crypto/abstract"
+	"github.com/dedis/crypto/ed25519"
+	"github.com/dedis/crypto/hash"
+	"github.com/dedis/crypto/random"
+)
+
+var suite = ed25519.NewAES128SHA256Ed25519(false)
+
+func TestStreamChunk(t *testing.T) {
+	var buff bytes.Buffer
+	str := "Hello World"
+	buff.WriteString(str)
+	hashed, err := hash.StreamChunk(suite.Hash(), &buff, 32)
+	if err != nil {
+		t.Fatal("error hashing" + err.Error())
+	}
+	h := suite.Hash()
+	h.Write([]byte(str))
+	b := h.Sum(nil)
+	if !bytes.Equal(b, hashed) {
+		t.Fatal("Hashes not equal")
+	}
+}
+
+func TestFileChunk(t *testing.T) {
+	tmpfileIO, err := ioutil.TempFile("", "hash_test.bin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpfileIO.Close()
+	tmpfile := tmpfileIO.Name()
+	defer os.Remove(tmpfile)
+	for _, i := range []int{16, 32, 128, 1024, 1536, 2048, 10001} {
+		buf := make([]byte, i)
+		_, err := rand.Read(buf)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := ioutil.WriteFile(tmpfile, buf, 0777); err != nil {
+			t.Fatal("Could not write file")
+		}
+		hash, err := hash.FileChunk(suite.Hash(), tmpfile, i)
+		if err != nil {
+			t.Fatal("Could not hash", tmpfile, err)
+		}
+		if len(hash) != 32 {
+			t.Fatal("Output of SHA256 should be 32 bytes")
+		}
+	}
+}
+
+func TestArgs(t *testing.T) {
+
+	x := suite.Scalar().Pick(random.Stream)
+	y := suite.Scalar().Pick(random.Stream)
+	X, _ := suite.Point().Pick(nil, random.Stream)
+	Y, _ := suite.Point().Pick(nil, random.Stream)
+
+	h1, err := hash.Args(suite.Hash(), x, y)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	h2, err := hash.Args(suite.Hash(), X, Y)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	h3, err := hash.Args(suite.Hash(), x, y, X, Y)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	h4, err := hash.Args(suite.Hash(), x, y, X, Y, []abstract.Scalar{x, y, x}, []abstract.Point{Y, X, Y})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if bytes.Equal(h1, h2) || bytes.Equal(h2, h3) || bytes.Equal(h3, h4) {
+		t.Fatal("Unexpectably obtained equal hashes")
+	}
+
+	h5, err := hash.Args(suite.Hash(), x, x, y, y)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	h6, err := hash.Args(suite.Hash(), []abstract.Scalar{x, x, y, y})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(h5, h6) {
+		t.Fatal("Hashes do not match")
+	}
+
+	h7, err := hash.Args(suite.Hash(), X, Y, Y, X)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	h8, err := hash.Args(suite.Hash(), []abstract.Point{X, Y, Y, X})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !bytes.Equal(h7, h8) {
+		t.Fatal("Hashes do not match")
+	}
+}

--- a/proof/dleq.go
+++ b/proof/dleq.go
@@ -1,0 +1,163 @@
+package proof
+
+import (
+	"errors"
+
+	"github.com/dedis/crypto/abstract"
+	"github.com/dedis/crypto/hash"
+	"github.com/dedis/crypto/random"
+)
+
+// This package provides functionality to create and verify non-interactive
+// zero-knowledge (NIZK) proofs for the equality (EQ) of discrete logarithms (DL).
+
+// DLEQ resembles a NIZK dlog-equality proof. Allows to handle multiple proofs.
+type DLEQ struct {
+	suite abstract.Suite
+	Base  []DLEQBase
+	Core  []DLEQCore
+}
+
+// DLEQBase contains the base points against which the core proof is created/verified.
+type DLEQBase struct {
+	g abstract.Point
+	h abstract.Point
+}
+
+// DLEQCore contains the core elements of the NIZK dlog-equality proof.
+type DLEQCore struct {
+	C  abstract.Scalar // challenge
+	R  abstract.Scalar // response
+	VG abstract.Point  // public commitment with respect to base point G
+	VH abstract.Point  // public commitment with respect to base point H
+}
+
+// NewDLEQ creates a new NIZK dlog-equality proof.
+func NewDLEQ(suite abstract.Suite, g []abstract.Point, h []abstract.Point, core []DLEQCore) (*DLEQ, error) {
+
+	if len(g) != len(h) {
+		return nil, errors.New("Received non-matching number of points")
+	}
+
+	n := len(g)
+	base := make([]DLEQBase, n)
+	for i := range base {
+		base[i] = DLEQBase{g: g[i], h: h[i]}
+	}
+
+	return &DLEQ{suite: suite, Base: base, Core: core}, nil
+}
+
+// Setup initializes the proof by randomly selecting a commitment v,
+// determining the challenge c = H(xG,xH,vG,vH) and the response r = v - cx.
+func (p *DLEQ) Setup(scalar ...abstract.Scalar) ([]abstract.Point, []abstract.Point, error) {
+
+	if len(scalar) != len(p.Base) {
+		return nil, nil, errors.New("Received unexpected number of scalars")
+	}
+
+	n := len(scalar)
+	p.Core = make([]DLEQCore, n)
+	xG := make([]abstract.Point, n)
+	xH := make([]abstract.Point, n)
+	for i, x := range scalar {
+
+		xG[i] = p.suite.Point().Mul(p.Base[i].g, x)
+		xH[i] = p.suite.Point().Mul(p.Base[i].h, x)
+
+		// Commitment
+		v := p.suite.Scalar().Pick(random.Stream)
+		vG := p.suite.Point().Mul(p.Base[i].g, v)
+		vH := p.suite.Point().Mul(p.Base[i].h, v)
+
+		// Challenge
+		cb, err := hash.Args(p.suite.Hash(), xG[i], xH[i], vG, vH)
+		if err != nil {
+			return nil, nil, err
+		}
+		c := p.suite.Scalar().Pick(p.suite.Cipher(cb))
+
+		// Response
+		r := p.suite.Scalar()
+		r.Mul(x, c).Sub(v, r)
+
+		p.Core[i] = DLEQCore{c, r, vG, vH}
+	}
+
+	return xG, xH, nil
+}
+
+// SetupCollective is similar to Setup with the difference that the challenge
+// is computed as the hash over all base points and commitments.
+func (p *DLEQ) SetupCollective(scalar ...abstract.Scalar) ([]abstract.Point, []abstract.Point, error) {
+
+	if len(scalar) != len(p.Base) {
+		return nil, nil, errors.New("Received unexpected number of scalars")
+	}
+
+	n := len(scalar)
+	p.Core = make([]DLEQCore, n)
+	v := make([]abstract.Scalar, n)
+	xG := make([]abstract.Point, n)
+	xH := make([]abstract.Point, n)
+	vG := make([]abstract.Point, n)
+	vH := make([]abstract.Point, n)
+	for i, x := range scalar {
+
+		xG[i] = p.suite.Point().Mul(p.Base[i].g, x)
+		xH[i] = p.suite.Point().Mul(p.Base[i].h, x)
+
+		// Commitments
+		v[i] = p.suite.Scalar().Pick(random.Stream)
+		vG[i] = p.suite.Point().Mul(p.Base[i].g, v[i])
+		vH[i] = p.suite.Point().Mul(p.Base[i].h, v[i])
+	}
+
+	// Collective challenge
+	cb, err := hash.Args(p.suite.Hash(), xG, xH, vG, vH)
+	if err != nil {
+		return nil, nil, err
+	}
+	c := p.suite.Scalar().Pick(p.suite.Cipher(cb))
+
+	// Responses
+	for i, x := range scalar {
+		r := p.suite.Scalar()
+		r.Mul(x, c).Sub(v[i], r)
+		p.Core[i] = DLEQCore{c, r, vG[i], vH[i]}
+	}
+
+	return xG, xH, nil
+}
+
+// Verify validates the proof(s) against the given input by checking that vG ==
+// rG + c(xG) and vH == rH + c(xH) and returns the indices of those proofs that
+// are valid (good) and non-valid (bad), respectively.
+func (p *DLEQ) Verify(xG []abstract.Point, xH []abstract.Point) ([]int, []int, error) {
+
+	if len(xG) != len(xH) {
+		return nil, nil, errors.New("Received unexpected number of points")
+	}
+
+	var good, bad []int
+	for i := range p.Base {
+		if xG[i].Equal(p.suite.Point().Null()) || xH[i].Equal(p.suite.Point().Null()) {
+			bad = append(bad, i)
+		} else {
+			rG := p.suite.Point().Mul(p.Base[i].g, p.Core[i].R)
+			rH := p.suite.Point().Mul(p.Base[i].h, p.Core[i].R)
+			cxG := p.suite.Point().Mul(xG[i], p.Core[i].C)
+			cxH := p.suite.Point().Mul(xH[i], p.Core[i].C)
+			a := p.suite.Point().Add(rG, cxG)
+			b := p.suite.Point().Add(rH, cxH)
+
+			if p.Core[i].VG.Equal(a) && p.Core[i].VH.Equal(b) {
+				good = append(good, i)
+			} else {
+				bad = append(bad, i)
+			}
+		}
+	}
+
+	return good, bad, nil
+}

--- a/proof/dleq_test.go
+++ b/proof/dleq_test.go
@@ -1,0 +1,106 @@
+package proof_test
+
+import (
+	"testing"
+
+	"github.com/dedis/crypto/abstract"
+	"github.com/dedis/crypto/edwards"
+	"github.com/dedis/crypto/proof"
+	"github.com/dedis/crypto/random"
+)
+
+func TestDLEQ(t *testing.T) {
+
+	suite := edwards.NewAES128SHA256Ed25519(false)
+
+	// 1st set of base points
+	g1, _ := suite.Point().Pick([]byte("G1"), random.Stream)
+	h1, _ := suite.Point().Pick([]byte("H1"), random.Stream)
+
+	// 1st secret value
+	x := suite.Scalar().Pick(random.Stream)
+
+	// 2nd set of base points
+	g2, _ := suite.Point().Pick([]byte("G2"), random.Stream)
+	h2, _ := suite.Point().Pick([]byte("H2"), random.Stream)
+
+	// 2nd secret value
+	y := suite.Scalar().Pick(random.Stream)
+
+	// Create proofs
+	g := []abstract.Point{g1, g2}
+	h := []abstract.Point{h1, h2}
+	p, err := proof.NewDLEQ(suite, g, h, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	xG, xH, err := p.Setup(x, y)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify proofs
+	q, err := proof.NewDLEQ(suite, g, h, p.Core)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, bad, err := q.Verify(xG, xH)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(bad) != 0 {
+		t.Fatalf("Some proofs failed: %v", bad)
+	}
+
+}
+
+func TestDLEQCollective(t *testing.T) {
+
+	suite := edwards.NewAES128SHA256Ed25519(false)
+
+	// 1st set of base points
+	g1, _ := suite.Point().Pick([]byte("G1"), random.Stream)
+	h1, _ := suite.Point().Pick([]byte("H1"), random.Stream)
+
+	// 1st secret value
+	x := suite.Scalar().Pick(random.Stream)
+
+	// 2nd set of base points
+	g2, _ := suite.Point().Pick([]byte("G2"), random.Stream)
+	h2, _ := suite.Point().Pick([]byte("H2"), random.Stream)
+
+	// 2nd secret value
+	y := suite.Scalar().Pick(random.Stream)
+
+	// Create proof
+	g := []abstract.Point{g1, g2}
+	h := []abstract.Point{h1, h2}
+	p, err := proof.NewDLEQ(suite, g, h, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	xG, xH, err := p.SetupCollective(x, y)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify proof
+	q, err := proof.NewDLEQ(suite, g, h, p.Core)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, bad, err := q.Verify(xG, xH)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(bad) != 0 {
+		t.Fatalf("Some proofs failed: %v", bad)
+	}
+
+}


### PR DESCRIPTION
This PR brings the DLEQ proofs library developed alongside with randhound into the crypto repository. It's needed later for pvss.