### PR TITLE
More Flexibility for PVSS

### DIFF
--- a/share/pvss/pvss.go
+++ b/share/pvss/pvss.go
@@ -78,25 +78,31 @@ func EncShares(suite abstract.Suite, H abstract.Point, X []abstract.Point, secre
 // VerifyEncShare checks that the encrypted share sX satisfies
 // log_{H}(sH) == log_{X}(sX) where sH is the public commitment computed by
 // evaluating the public commitment polynomial at the encrypted share's index i.
-func VerifyEncShare(suite abstract.Suite, H abstract.Point, X abstract.Point, poly *share.PubPoly, encShare *PubVerShare) error {
-	sH := poly.Eval(encShare.S.I)
+func VerifyEncShare(suite abstract.Suite, H abstract.Point, X abstract.Point, sH *share.PubShare, encShare *PubVerShare) error {
 	if err := encShare.P.Verify(suite, H, X, sH.V, encShare.S.V); err != nil {
 		return errorEncVerification
 	}
 	return nil
 }
 
+// VerifyEncSharePoly is a wrapper around VerifyEncShare that recovers the
+// commit from the given polynomial first.
+func VerifyEncSharePoly(suite abstract.Suite, H abstract.Point, X abstract.Point, poly *share.PubPoly, encShare *PubVerShare) error {
+	sH := poly.Eval(encShare.S.I)
+	return VerifyEncShare(suite, H, X, sH, encShare)
+}
+
 // VerifyEncShareBatch provides the same functionality as VerifyEncShare but for
 // slices of encrypted shares. The function returns the valid encrypted shares
 // together with the corresponding public keys.
-func VerifyEncShareBatch(suite abstract.Suite, H abstract.Point, X []abstract.Point, polys []*share.PubPoly, encShares []*PubVerShare) ([]abstract.Point, []*PubVerShare, error) {
-	if len(X) != len(polys) || len(polys) != len(encShares) {
+func VerifyEncShareBatch(suite abstract.Suite, H abstract.Point, X []abstract.Point, sH []*share.PubShare, encShares []*PubVerShare) ([]abstract.Point, []*PubVerShare, error) {
+	if len(X) != len(sH) || len(sH) != len(encShares) {
 		return nil, nil, errorDifferentLengths
 	}
 	var K []abstract.Point // good public keys
 	var E []*PubVerShare   // good encrypted shares
 	for i := 0; i < len(X); i++ {
-		if err := VerifyEncShare(suite, H, X[i], polys[i], encShares[i]); err == nil {
+		if err := VerifyEncShare(suite, H, X[i], sH[i], encShares[i]); err == nil {
 			K = append(K, X[i])
 			E = append(E, encShares[i])
 		}
@@ -104,11 +110,24 @@ func VerifyEncShareBatch(suite abstract.Suite, H abstract.Point, X []abstract.Po
 	return K, E, nil
 }
 
+// VerifyEncSharePolyBatch is a wrapper around VerifyEncShareBatch that recovers
+// the commits from the given polynomials first.
+func VerifyEncSharePolyBatch(suite abstract.Suite, H abstract.Point, X []abstract.Point, polys []*share.PubPoly, encShares []*PubVerShare) ([]abstract.Point, []*PubVerShare, error) {
+	if len(X) != len(polys) || len(polys) != len(encShares) {
+		return nil, nil, errorDifferentLengths
+	}
+	sH := make([]*share.PubShare, len(polys))
+	for i, poly := range polys {
+		sH[i] = poly.Eval(encShares[i].S.I)
+	}
+	return VerifyEncShareBatch(suite, H, X, sH, encShares)
+}
+
 // DecShare first verifies the encrypted share against the encryption
 // consistency proof and, if valid, decrypts it and creates a decryption
 // consistency proof.
-func DecShare(suite abstract.Suite, H abstract.Point, X abstract.Point, poly *share.PubPoly, x abstract.Scalar, encShare *PubVerShare) (*PubVerShare, error) {
-	if err := VerifyEncShare(suite, H, X, poly, encShare); err != nil {
+func DecShare(suite abstract.Suite, H abstract.Point, X abstract.Point, sH *share.PubShare, x abstract.Scalar, encShare *PubVerShare) (*PubVerShare, error) {
+	if err := VerifyEncShare(suite, H, X, sH, encShare); err != nil {
 		return nil, err
 	}
 	G := suite.Point().Base()
@@ -121,24 +140,44 @@ func DecShare(suite abstract.Suite, H abstract.Point, X abstract.Point, poly *sh
 	return &PubVerShare{*ps, *P}, nil
 }
 
+// DecSharePoly is a wrapper around DecShare that recovers the commit
+// from the given polynomial first.
+func DecSharePoly(suite abstract.Suite, H abstract.Point, X abstract.Point, poly *share.PubPoly, x abstract.Scalar, encShare *PubVerShare) (*PubVerShare, error) {
+	sH := poly.Eval(encShare.S.I)
+	return DecShare(suite, H, X, sH, x, encShare)
+}
+
 // DecShareBatch provides the same functionality as DecShare but for slices of
 // encrypted shares. The function returns the valid encrypted and decrypted
 // shares as well as the corresponding public keys.
-func DecShareBatch(suite abstract.Suite, H abstract.Point, X []abstract.Point, polys []*share.PubPoly, x abstract.Scalar, encShares []*PubVerShare) ([]abstract.Point, []*PubVerShare, []*PubVerShare, error) {
-	if len(X) != len(polys) || len(polys) != len(encShares) {
+func DecShareBatch(suite abstract.Suite, H abstract.Point, X []abstract.Point, sH []*share.PubShare, x abstract.Scalar, encShares []*PubVerShare) ([]abstract.Point, []*PubVerShare, []*PubVerShare, error) {
+	if len(X) != len(sH) || len(sH) != len(encShares) {
 		return nil, nil, nil, errorDifferentLengths
 	}
 	var K []abstract.Point // good public keys
 	var E []*PubVerShare   // good encrypted shares
 	var D []*PubVerShare   // good decrypted shares
 	for i := 0; i < len(encShares); i++ {
-		if ds, err := DecShare(suite, H, X[i], polys[i], x, encShares[i]); err == nil {
+		if ds, err := DecShare(suite, H, X[i], sH[i], x, encShares[i]); err == nil {
 			K = append(K, X[i])
 			E = append(E, encShares[i])
 			D = append(D, ds)
 		}
 	}
 	return K, E, D, nil
+}
+
+// DecSharePolyBatch is a wrapper around DecShareBatch that recovers the commits
+// from the given polynomials first.
+func DecSharePolyBatch(suite abstract.Suite, H abstract.Point, X []abstract.Point, polys []*share.PubPoly, x abstract.Scalar, encShares []*PubVerShare) ([]abstract.Point, []*PubVerShare, []*PubVerShare, error) {
+	if len(X) != len(polys) || len(polys) != len(encShares) {
+		return nil, nil, nil, errorDifferentLengths
+	}
+	sH := make([]*share.PubShare, len(polys))
+	for i, poly := range polys {
+		sH[i] = poly.Eval(encShares[i].S.I)
+	}
+	return DecShareBatch(suite, H, X, sH, x, encShares)
 }
 
 // VerifyDecShare checks that the decrypted share sG satisfies

--- a/share/pvss/pvss_test.go
+++ b/share/pvss/pvss_test.go
@@ -41,7 +41,7 @@ func TestPVSS(test *testing.T) {
 	var D []*PubVerShare   // good decrypted shares
 
 	for i := 0; i < n; i++ {
-		if ds, err := DecShare(suite, H, X[i], polys[i], x[i], encShares[i]); err == nil {
+		if ds, err := DecSharePoly(suite, H, X[i], polys[i], x[i], encShares[i]); err == nil {
 			K = append(K, X[i])
 			E = append(E, encShares[i])
 			D = append(D, ds)
@@ -89,7 +89,7 @@ func TestPVSSDelete(test *testing.T) {
 	var D []*PubVerShare   // good decrypted shares
 
 	for i := 0; i < n; i++ {
-		if ds, err := DecShare(suite, H, X[i], polys[i], x[i], encShares[i]); err == nil {
+		if ds, err := DecSharePoly(suite, H, X[i], polys[i], x[i], encShares[i]); err == nil {
 			K = append(K, X[i])
 			E = append(E, encShares[i])
 			D = append(D, ds)
@@ -140,7 +140,7 @@ func TestPVSSDeleteFail(test *testing.T) {
 	var D []*PubVerShare   // good decrypted shares
 
 	for i := 0; i < n; i++ {
-		if ds, err := DecShare(suite, H, X[i], polys[i], x[i], encShares[i]); err == nil {
+		if ds, err := DecSharePoly(suite, H, X[i], polys[i], x[i], encShares[i]); err == nil {
 			K = append(K, X[i])
 			E = append(E, encShares[i])
 			D = append(D, ds)
@@ -192,13 +192,13 @@ func TestPVSSBatch(test *testing.T) {
 	}
 
 	// Batch verification
-	X0, E0, err := VerifyEncShareBatch(suite, H, X, p0s, e0)
+	X0, E0, err := VerifyEncSharePolyBatch(suite, H, X, p0s, e0)
 	require.Equal(test, err, nil)
 
-	X1, E1, err := VerifyEncShareBatch(suite, H, X, p1s, e1)
+	X1, E1, err := VerifyEncSharePolyBatch(suite, H, X, p1s, e1)
 	require.Equal(test, err, nil)
 
-	X2, E2, err := VerifyEncShareBatch(suite, H, X, p2s, e2)
+	X2, E2, err := VerifyEncSharePolyBatch(suite, H, X, p2s, e2)
 	require.Equal(test, err, nil)
 
 	// Reorder (some) polys, keys, and shares
@@ -215,16 +215,16 @@ func TestPVSSBatch(test *testing.T) {
 	Z3 := []*PubVerShare{E0[3], E1[3], E2[3]}
 
 	// (2) Share batch decryption (trustees)
-	KD0, ED0, DD0, err := DecShareBatch(suite, H, Y0, P, x[0], Z0)
+	KD0, ED0, DD0, err := DecSharePolyBatch(suite, H, Y0, P, x[0], Z0)
 	require.Equal(test, err, nil)
 
-	KD1, ED1, DD1, err := DecShareBatch(suite, H, Y1, P, x[1], Z1)
+	KD1, ED1, DD1, err := DecSharePolyBatch(suite, H, Y1, P, x[1], Z1)
 	require.Equal(test, err, nil)
 
-	KD2, ED2, DD2, err := DecShareBatch(suite, H, Y2, P, x[2], Z2)
+	KD2, ED2, DD2, err := DecSharePolyBatch(suite, H, Y2, P, x[2], Z2)
 	require.Equal(test, err, nil)
 
-	KD3, ED3, DD3, err := DecShareBatch(suite, H, Y3, P, x[3], Z3)
+	KD3, ED3, DD3, err := DecSharePolyBatch(suite, H, Y3, P, x[3], Z3)
 	require.Equal(test, err, nil)
 
 	// Re-establish order


### PR DESCRIPTION
This patch adds some more flexibility to PVSS at the cost of a slight increase in usage complexity. 
Instead of taking the commitment polynomials as input and evaluating them, the functions take now the evaluated values as inputs pushing the responsibility to evaluate the polynomials to the users.