### PR TITLE
adding schnorr signatures

### DIFF
--- a/sign/schnorr.go
+++ b/sign/schnorr.go
@@ -1,0 +1,93 @@
+package sign
+
+import (
+	"bytes"
+	"crypto/sha512"
+	"errors"
+	"fmt"
+
+	"github.com/dedis/crypto/abstract"
+	"github.com/dedis/crypto/random"
+)
+
+// Schnorr creates a Schnorr signature from a msg and a private key. This
+// signature can be verified with VerifySchnorr. It's also a valid EdDSA
+// signature.
+func Schnorr(suite abstract.Suite, private abstract.Scalar, msg []byte) ([]byte, error) {
+	// create random secret k and public point commitment R
+	k := suite.Scalar().Pick(random.Stream)
+	R := suite.Point().Mul(nil, k)
+
+	// create hash(public || R || message)
+	public := suite.Point().Mul(nil, private)
+	h, err := hash(suite, public, R, msg)
+	if err != nil {
+		return nil, err
+	}
+
+	// compute response s = k + x*h
+	xh := suite.Scalar().Mul(private, h)
+	s := suite.Scalar().Add(k, xh)
+
+	// return R || s
+	var b bytes.Buffer
+	if _, err := R.MarshalTo(&b); err != nil {
+		return nil, err
+	}
+	if _, err := s.MarshalTo(&b); err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
+}
+
+// VerifySchnorr verifies a given Schnorr signature. It returns nil iff the
+// given signature is valid.  NOTE: this signature scheme is malleable because
+// the response's unmarshalling is done directly into a big.Int modulo (see
+// nist.Int).
+func VerifySchnorr(suite abstract.Suite, public abstract.Point, msg, sig []byte) error {
+	R := suite.Point()
+	s := suite.Scalar()
+	pointSize := R.MarshalSize()
+	scalarSize := s.MarshalSize()
+	sigSize := scalarSize + pointSize
+	if len(sig) != sigSize {
+		return fmt.Errorf("schnorr: signature of invalid length %d instead of %d", len(sig), sigSize)
+	}
+	if err := R.UnmarshalBinary(sig[:pointSize]); err != nil {
+		return err
+	}
+	if err := s.UnmarshalBinary(sig[pointSize:]); err != nil {
+		return err
+	}
+	// recompute hash(public || R || msg)
+	h, err := hash(suite, public, R, msg)
+	if err != nil {
+		return err
+	}
+
+	// compute S = g^s
+	S := suite.Point().Mul(nil, s)
+	// compute RAh = R + A^h
+	Ah := suite.Point().Mul(public, h)
+	RAs := suite.Point().Add(R, Ah)
+
+	if !S.Equal(RAs) {
+		return errors.New("schnorr: invalid signature")
+	}
+
+	return nil
+}
+
+func hash(suite abstract.Suite, public, r abstract.Point, msg []byte) (abstract.Scalar, error) {
+	h := sha512.New()
+	if _, err := r.MarshalTo(h); err != nil {
+		return nil, err
+	}
+	if _, err := public.MarshalTo(h); err != nil {
+		return nil, err
+	}
+	if _, err := h.Write(msg); err != nil {
+		return nil, err
+	}
+	return suite.Scalar().SetBytes(h.Sum(nil)), nil
+}

--- a/sign/schnorr_test.go
+++ b/sign/schnorr_test.go
@@ -1,0 +1,64 @@
+package sign
+
+import (
+	"testing"
+
+	"github.com/dedis/crypto/config"
+	"github.com/dedis/crypto/ed25519"
+	"github.com/dedis/crypto/eddsa"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSchnorrSignature(t *testing.T) {
+	msg := []byte("Hello Schnorr")
+	suite := ed25519.NewAES128SHA256Ed25519(false)
+	kp := config.NewKeyPair(suite)
+
+	s, err := Schnorr(suite, kp.Secret, msg)
+	if err != nil {
+		t.Fatalf("Couldn't sign msg: %s: %v", msg, err)
+	}
+	err = VerifySchnorr(suite, kp.Public, msg, s)
+	if err != nil {
+		t.Fatalf("Couldn't verify signature: \n%+v\nfor msg:'%s'. Error:\n%v", s, msg, err)
+	}
+
+	// wrong size
+	larger := append(s, []byte{0x01, 0x02}...)
+	assert.Error(t, VerifySchnorr(suite, kp.Public, msg, larger))
+
+	// wrong challenge
+	wrongEncoding := []byte{243, 45, 180, 140, 73, 23, 41, 212, 250, 87, 157, 243,
+		242, 19, 114, 161, 145, 47, 76, 26, 174, 150, 22, 177, 78, 79, 122, 30, 74,
+		42, 156, 203}
+	wrChall := make([]byte, len(s))
+	copy(wrChall[:32], wrongEncoding)
+	copy(wrChall[32:], s[32:])
+	assert.Error(t, VerifySchnorr(suite, kp.Public, msg, wrChall))
+
+	// wrong response
+	wrResp := make([]byte, len(s))
+	copy(wrResp[32:], wrongEncoding)
+	copy(wrResp[:32], s[:32])
+	assert.Error(t, VerifySchnorr(suite, kp.Public, msg, wrResp))
+
+	// wrong public key
+	wrKp := config.NewKeyPair(suite)
+	assert.Error(t, VerifySchnorr(suite, wrKp.Public, msg, s))
+}
+
+func TestEdDSACompatibility(t *testing.T) {
+	msg := []byte("Hello Schnorr")
+	suite := ed25519.NewAES128SHA256Ed25519(false)
+	kp := config.NewKeyPair(suite)
+
+	s, err := Schnorr(suite, kp.Secret, msg)
+	if err != nil {
+		t.Fatalf("Couldn't sign msg: %s: %v", msg, err)
+	}
+	err = eddsa.Verify(kp.Public, msg, s)
+	if err != nil {
+		t.Fatalf("Couldn't verify signature: \n%+v\nfor msg:'%s'. Error:\n%v", s, msg, err)
+	}
+
+}


### PR DESCRIPTION
Schnorr signatures were not present in v0. Since cothority uses v0, and that some people need the schnorr signature, we need to integrate them into v0.